### PR TITLE
fix: allow null on quote of mypage

### DIFF
--- a/prisma/migrations/20240722123257_change_mypage_quote_to_nullable/migration.sql
+++ b/prisma/migrations/20240722123257_change_mypage_quote_to_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "mypage" ALTER COLUMN "quote" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,7 @@ model Mypage {
   id        Int      @id @default(autoincrement())
   title     String
   url       String
-  quote     String
+  quote     String?
   status    Status   @default(UNEXPORTED)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/script/create_blog_pr.sh
+++ b/script/create_blog_pr.sh
@@ -3,12 +3,12 @@
 npm run corepack
 pnpm i --frozen-lockfile
 
-git clone https://github.com/s-hirano-ist/blog
+git clone https://github.com/s-hirano-ist/s-public
 
 # Genrate files
 pnpm blog
 
-cd blog
+cd s-public
 
 # Git
 git config --global user.name ${GITHUB_USER_NAME}
@@ -23,7 +23,7 @@ git add -A
 git commit -m "contents: update news"
 
 # Push to GitHub
-REPO_URL="https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/blog.git"
+REPO_URL="https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/s-public.git"
 git push $REPO_URL $branch_name
 
 # Make PR
@@ -31,10 +31,10 @@ curl \
     -X POST \
     -H "Authorization: token ${GITHUB_SECRET_KEY}" \
     -H "Accept: application/vnd.github.v3+json" \
-    https://api.github.com/repos/s-hirano-ist/blog/pulls \
+    https://api.github.com/repos/s-hirano-ist/s-public/pulls \
     -d '{
         "title": "contents: update news",
-        "body": "https://github.com/s-hirano-ist/s-private から取得したエクスポートしたニュース一覧。",
+        "body": "https://github.com/s-hirano-ist/s-public から取得したエクスポートしたニュース一覧。",
         "base": "main",
         "head": "'${branch_name}'"
     }'

--- a/script/create_mypage_pr.sh
+++ b/script/create_mypage_pr.sh
@@ -3,12 +3,12 @@
 npm run corepack
 pnpm i --frozen-lockfile
 
-git clone https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/mypage.git
+git clone https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/s-contents.git
 
 # Genrate files
 pnpm mypage
 
-cd mypage
+cd s-contents
 
 # Git
 git config --global user.name ${GITHUB_USER_NAME}
@@ -23,7 +23,7 @@ git add -A
 git commit -m "contents: update content"
 
 # Push to GitHub
-REPO_URL="https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/mypage.git"
+REPO_URL="https://${GITHUB_SECRET_KEY}@github.com/s-hirano-ist/s-contents.git"
 git push $REPO_URL $branch_name
 
 # Make PR
@@ -31,10 +31,10 @@ curl \
     -X POST \
     -H "Authorization: token ${GITHUB_SECRET_KEY}" \
     -H "Accept: application/vnd.github.v3+json" \
-    https://api.github.com/repos/s-hirano-ist/mypage/pulls \
+    https://api.github.com/repos/s-hirano-ist/s-contents/pulls \
     -d '{
         "title": "contents: update content",
-        "body": "https://github.com/s-hirano-ist/s-private から取得したエクスポートしたコンテンツ一覧。",
+        "body": "https://github.com/s-hirano-ist/s-contents から取得したエクスポートしたコンテンツ一覧。",
         "base": "main",
         "head": "'${branch_name}'"
     }'

--- a/script/pr-blog.ts
+++ b/script/pr-blog.ts
@@ -7,7 +7,7 @@ type Blog = {
 	title: string;
 	url: string;
 	quote: string | null;
-	category: string;
+	name: string;
 };
 
 type Template = {
@@ -46,9 +46,9 @@ type OutputType = {
 
 function categorizeBlog(blogs: Blog[]): OutputType {
 	return blogs.reduce((acc, blog) => {
-		if (!acc[blog.category]) acc[blog.category] = [];
+		if (!acc[blog.name]) acc[blog.name] = [];
 		const { title, quote, url } = blog;
-		acc[blog.category].push({ title, quote: quote ?? "", url });
+		acc[blog.name].push({ title, quote: quote ?? "", url });
 		return acc;
 	}, {} as OutputType);
 }

--- a/src/features/mypage/actions/add-mypage.ts
+++ b/src/features/mypage/actions/add-mypage.ts
@@ -17,7 +17,7 @@ export async function addMypage(formData: FormData): Promise<AddMypageState> {
 		await sendLineNotifyMessage(
 			formatCreateContentMessage(
 				newMypage.title,
-				newMypage.quote,
+				newMypage.quote ?? "",
 				newMypage.url,
 				"MYPAGE",
 			),

--- a/src/features/mypage/components/mypage-add-form.tsx
+++ b/src/features/mypage/components/mypage-add-form.tsx
@@ -52,7 +52,7 @@ export function MypageAddForm() {
 			</div>
 			<div className="space-y-1">
 				<Label htmlFor="quote">ひとこと</Label>
-				<Textarea id="quote" name="quote" ref={quoteInputRef} required />
+				<Textarea id="quote" name="quote" ref={quoteInputRef} />
 			</div>
 			<div className="space-y-1">
 				<Label htmlFor="url">URL</Label>

--- a/src/features/mypage/components/mypage-contents.tsx
+++ b/src/features/mypage/components/mypage-contents.tsx
@@ -12,7 +12,7 @@ export async function MypageContents() {
 					return {
 						id: d.id,
 						title: d.title,
-						quote: d.quote,
+						quote: d.quote ?? "",
 						url: d.url,
 					};
 				})}

--- a/src/features/mypage/components/mypage-table.tsx
+++ b/src/features/mypage/components/mypage-table.tsx
@@ -13,7 +13,7 @@ export async function MypageTable() {
 					return {
 						id: d.id,
 						title: d.title,
-						quote: d.quote,
+						quote: d.quote ?? "",
 						url: d.url,
 						status: d.status,
 					};

--- a/src/features/mypage/schemas/mypage-schema.ts
+++ b/src/features/mypage/schemas/mypage-schema.ts
@@ -7,9 +7,6 @@ export const mypageSchema = z.object({
 		.string()
 		.min(1, { message: FORM_ERROR_MESSAGES.REQUIRED })
 		.max(32, { message: FORM_ERROR_MESSAGES.TOO_LONG }),
-	quote: z
-		.string()
-		.min(1, { message: FORM_ERROR_MESSAGES.REQUIRED })
-		.max(256, { message: FORM_ERROR_MESSAGES.TOO_LONG }),
+	quote: z.string().max(256, { message: FORM_ERROR_MESSAGES.TOO_LONG }),
 	url: z.string().url().min(1, { message: FORM_ERROR_MESSAGES.REQUIRED }),
 });


### PR DESCRIPTION
Fixes #233 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- マイページの「引用」フィールドを任意に変更し、NULL値を許可しました。
  
- **バグ修正**
	- マイページ追加フォームの「引用」フィールドの必須属性を削除し、空の引用を許可しました。

- **ドキュメント**
	- スクリプトでのリポジトリ名の変更（`blog` から `s-public`、`mypage` から `s-contents` に更新）。

- **リファクタリング**
	- ブログカテゴリの識別子を「カテゴリー」から「名前」に変更し、集約ロジックを更新しました。

- **スキーマの変更**
	- 「引用」フィールドの検証ロジックを簡素化し、最小長の要件を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->