### PR TITLE
fix: 🐛 reset atoms on signout

### DIFF
--- a/src/components/nav/header.tsx
+++ b/src/components/nav/header.tsx
@@ -2,8 +2,11 @@
 import { Button } from "@/components/ui/button";
 import { DEFAULT_SIGN_OUT_REDIRECT } from "@/constants";
 import { signOut } from "@/features/auth/actions/sign-out";
+import { contentsAtom } from "@/features/contents/stores/contents-atom";
+import { newsAtom } from "@/features/news/stores/news-atom";
 import { useToast } from "@/hooks/use-toast";
 import { sanitizeHref } from "@/utils/sanitize-href";
+import { useResetAtom } from "jotai/utils";
 import { LogOutIcon } from "lucide-react";
 import { Link, useTransitionRouter } from "next-view-transitions";
 // import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
@@ -20,9 +23,14 @@ export function Header({ title, url }: Props) {
 	const { toast } = useToast();
 	const router = useTransitionRouter();
 
+	const resetNews = useResetAtom(newsAtom);
+	const resetContents = useResetAtom(contentsAtom);
+
 	async function onSignOutSubmit() {
 		const response = await signOut();
 		if (response.success) {
+			resetNews();
+			resetContents();
 			router.push(DEFAULT_SIGN_OUT_REDIRECT);
 		} else {
 			toast({

--- a/src/features/contents/stores/contents-atom.ts
+++ b/src/features/contents/stores/contents-atom.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { atomWithReset } from "jotai/utils";
 
 export type ContentsAtom = {
 	id: number;
@@ -7,4 +8,6 @@ export type ContentsAtom = {
 	url: string;
 };
 
-export const contentsAtom = atom<ContentsAtom[] | undefined>(undefined);
+export const contentsAtom = atomWithReset<ContentsAtom[] | undefined>(
+	undefined,
+);

--- a/src/features/news/stores/news-atom.ts
+++ b/src/features/news/stores/news-atom.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { atomWithReset } from "jotai/utils";
 
 export type NewsAtom = {
 	id: number;
@@ -8,4 +9,4 @@ export type NewsAtom = {
 	category: string;
 };
 
-export const newsAtom = atom<NewsAtom[] | undefined>(undefined);
+export const newsAtom = atomWithReset<NewsAtom[] | undefined>(undefined);


### PR DESCRIPTION
Fixes #410 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーのサインアウト時に、ニュースとコンテンツの状態をリセットする機能を追加しました。これにより、サインアウト後のユーザー体験が向上します。

- **バグ修正**
  - サインアウトプロセスの改善により、関連するアプリケーションの状態が適切にクリアされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->