### PR TITLE
fix: 🐛 change node alpine image to node slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,14 @@
 # Build Stage
-# MEMO: alpine iamges may snot recommended? https://zenn.dev/jrsyo/articles/e42de409e62f5d
-FROM node:22.12.0-alpine@sha256:6e80991f69cc7722c561e5d14d5e72ab47c0d6b6cfb3ae50fb9cf9a7b30fdf97 AS base
+# MEMO: alpine based iamges is not recommended for prod useage https://github.com/nodejs/docker-node#nodealpine
 
-# MEMO: when using node-slim
-# FROM node:20.18.0-slim@sha256:ec35a66c9a0a275b027debde05247c081f8b2f0c43d7399d3a6ad5660cee2f6a AS base
-# RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+FROM node:20.18.0-slim@sha256:ec35a66c9a0a275b027debde05247c081f8b2f0c43d7399d3a6ad5660cee2f6a AS base
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
 # Install pnpm
 RUN npm install -g pnpm
 
 # Install dependencies only when needed
 FROM base AS deps
-
-# MEMO: only uncommennt when using node-alpine
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Dockerfileのベースイメージが`node:22.12.0-alpine`から`node:20.18.0-slim`に更新されました。
	- 必要な証明書を確保するために`ca-certificates`のインストールが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->