### PR TITLE
contents: update licenses

### DIFF
--- a/library-license.txt
+++ b/library-license.txt
@@ -1,9 +1,10 @@
-├─ MIT: 91
-├─ Apache-2.0: 6
-├─ ISC: 5
-├─ BSD-2-Clause: 3
+├─ MIT: 111
+├─ Apache-2.0: 12
+├─ ISC: 3
+├─ BSD-2-Clause: 2
 ├─ MIT OR Apache-2.0: 1
+├─ Custom: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions: 1
 ├─ Unlicense: 1
 ├─ BSD-3-Clause: 1
-└─ MIT*: 1
+└─ Custom: https://img.shields.io/badge/License-AGPL: 1
 


### PR DESCRIPTION
This is an update PR of auto generated licenses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ライセンス更新**
	- MITライセンスの数が91から111に増加
	- Apache-2.0ライセンスの数が6から12に増加
	- ISCライセンスの数が5から3に減少
	- BSD-2-Clauseライセンスの数が3から2に減少
	- 新しいカスタムライセンスエントリを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->