### PR TITLE
fix: 🐛 server actions body size limit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,7 +29,10 @@ const cspHeader = `
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	experimental: { typedRoutes: true },
+	experimental: {
+		typedRoutes: true,
+		serverActions: { bodySizeLimit: "100mb" }, // FIXME: due to DDoS attacks
+	},
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 	output: "standalone",
 	images: { remotePatterns: [{ hostname: env.MINIO_HOST }] },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ改善**
	- サーバーアクションのリクエストボディサイズ制限を100MBに拡張
	- より大きなデータペイロードの処理をサポート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->