### PR TITLE
fix: 🐛 add cache strategy for prisma accelerate

### DIFF
--- a/src/app/(viewer)/books/[slug]/page.tsx
+++ b/src/app/(viewer)/books/[slug]/page.tsx
@@ -32,6 +32,7 @@ export default async function Page({ params }: { params: Params }) {
 	const data = await prisma.staticBooks.findUnique({
 		where: { title: decordedSlug },
 		select: { markdown: true },
+		cacheStrategy: { ttl: 400, tags: ["staticBooks"] },
 	});
 	if (!data) return <NotFound />;
 

--- a/src/app/(viewer)/contents/[slug]/page.tsx
+++ b/src/app/(viewer)/contents/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default async function Page({ params }: { params: Params }) {
 	const data = await prisma.staticContents.findUnique({
 		where: { title: slug },
 		select: { markdown: true },
+		cacheStrategy: { ttl: 400, tags: ["staticContents"] },
 	});
 	if (!data) return <NotFound />;
 

--- a/src/app/(viewer)/viewer/@books/page.tsx
+++ b/src/app/(viewer)/viewer/@books/page.tsx
@@ -16,6 +16,7 @@ export default async function Page() {
 
 	const images = await prisma.staticBooks.findMany({
 		select: { title: true, uint8ArrayImage: true },
+		cacheStrategy: { ttl: 400, tags: ["staticBooks"] },
 	});
 
 	return (

--- a/src/app/(viewer)/viewer/@contents/page.tsx
+++ b/src/app/(viewer)/viewer/@contents/page.tsx
@@ -16,6 +16,7 @@ export default async function Page() {
 
 	const images = await prisma.staticContents.findMany({
 		select: { title: true, uint8ArrayImage: true },
+		cacheStrategy: { ttl: 400, tags: ["staticContents"] },
 	});
 
 	return (

--- a/src/app/(viewer)/viewer/@images/page.tsx
+++ b/src/app/(viewer)/viewer/@images/page.tsx
@@ -24,6 +24,7 @@ export default async function Page({ params }: { params: Params }) {
 	const userId = await getSelfId();
 	const totalImages = await prisma.images.count({
 		where: { userId },
+		cacheStrategy: { ttl: 400, swr: 40, tags: ["images"] },
 	});
 
 	return (

--- a/src/components/body/viewer-body.tsx
+++ b/src/components/body/viewer-body.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
 
-type Props = {
-	children: ReactNode;
-};
+type Props = { children: ReactNode };
 
 export function ViewerBody({ children }: Props) {
 	return (

--- a/src/components/stack/pagination.tsx
+++ b/src/components/stack/pagination.tsx
@@ -8,10 +8,7 @@ import {
 } from "@/components/ui/pagination";
 import { PAGE_SIZE } from "@/constants";
 
-type Props = {
-	currentPage: number;
-	totalPages: number;
-};
+type Props = { currentPage: number; totalPages: number };
 
 export function Pagination({ currentPage, totalPages }: Props) {
 	const showPreviousPageLink = 1 < currentPage;

--- a/src/features/image/actions/add-image.ts
+++ b/src/features/image/actions/add-image.ts
@@ -56,6 +56,7 @@ export async function addImage(
 		});
 		await sendLineNotifyMessage(message);
 		revalidatePath("/(dumper)");
+		await prisma.$accelerate.invalidate({ tags: ["images"] });
 
 		return {
 			success: true,

--- a/src/features/image/components/all-image-stack.tsx
+++ b/src/features/image/components/all-image-stack.tsx
@@ -6,9 +6,7 @@ import { generateUrlWithMetadata } from "@/features/image/actions/generate-url-w
 import { loggerError } from "@/pino";
 import prisma from "@/prisma";
 
-type Props = {
-	page: number;
-};
+type Props = { page: number };
 
 export async function AllImageStack({ page }: Props) {
 	try {
@@ -22,6 +20,7 @@ export async function AllImageStack({ page }: Props) {
 			orderBy: { id: "desc" },
 			skip: (page - 1) * PAGE_SIZE,
 			take: PAGE_SIZE,
+			cacheStrategy: { ttl: 400, swr: 40, tags: ["images"] },
 		});
 
 		const images = await Promise.all(

--- a/vitest-setup.tsx
+++ b/vitest-setup.tsx
@@ -36,6 +36,7 @@ beforeEach(() => {
 			contents: { create: vi.fn(), findMany: vi.fn() },
 			images: { create: vi.fn(), findMany: vi.fn(), updateMany: vi.fn() },
 			$transaction: vi.fn(),
+			$accelerate: { invalidate: vi.fn() },
 		},
 	}));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- データ取得のパフォーマンスを向上させるため、様々なクエリに400秒の有効期限を持つキャッシュ戦略を導入しました。

- **スタイル**
	- いくつかのコンポーネントで型定義を単一行に簡略化しました。

- **改善**
	- 画像アップロード後のキャッシュ無効化機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->