### PR TITLE
fix: 🐛 session and jwt token exp

### DIFF
--- a/src/features/auth/utils/auth.ts
+++ b/src/features/auth/utils/auth.ts
@@ -28,8 +28,8 @@ export const {
 } = NextAuth({
 	...authConfig,
 	secret: env.AUTH_SECRET,
-	session: { strategy: "jwt", maxAge: 24 * 60 * 60 },
-	jwt: { maxAge: 30 * 24 * 60 * 60 },
+	session: { strategy: "jwt", maxAge: 30 * 24 * 60 * 60 },
+	jwt: { maxAge: 7 * 24 * 60 * 60 },
 	callbacks: {
 		jwt({ account, token, profile }) {
 			if (account && profile) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - セッションの有効期間を従来の24時間から30日に延長し、より長期間ログイン状態を維持できるようにしました。
  - 認証トークンの有効期間を従来の30日から7日に変更し、認証の仕組みを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->