### PR TITLE
feat: change link of static books to isbn

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -39,7 +39,17 @@ const nextConfig = {
 	},
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 	output: "standalone",
-	images: { remotePatterns: [{ hostname: process.env.MINIO_HOST }] },
+	images: {
+		domains: ["books.google.com"],
+		remotePatterns: [
+			{ hostname: process.env.MINIO_HOST },
+			{
+				protocol: "https",
+				hostname: "books.google.com",
+				pathname: "/books/content*",
+			},
+		],
+	},
 	async headers() {
 		return [
 			{

--- a/src/app/[locale]/(viewer)/books/[slug]/_page.tsx
+++ b/src/app/[locale]/(viewer)/books/[slug]/_page.tsx
@@ -9,10 +9,8 @@ type Props = { slug: string };
 export async function SuspensePage({ slug }: Props) {
 	const hasAdminPermission = await hasViewerAdminPermission();
 
-	const decodedSlug = decodeURIComponent(slug);
-
 	const data = await prisma.staticBooks.findUnique({
-		where: { title: decodedSlug },
+		where: { ISBN: slug },
 		select: { markdown: true },
 		cacheStrategy: { ttl: 400, tags: ["staticBooks"] },
 	});

--- a/src/app/[locale]/(viewer)/books/[slug]/page.tsx
+++ b/src/app/[locale]/(viewer)/books/[slug]/page.tsx
@@ -12,8 +12,8 @@ export async function generateMetadata({
 	const { slug } = await params;
 
 	return {
-		title: `${decodeURIComponent(slug)} | ${PAGE_NAME}`,
-		description: `Private book review of ${decodeURIComponent(slug)}`,
+		title: `${slug} | ${PAGE_NAME}`,
+		description: `Private book review of ${slug}`,
 	};
 }
 

--- a/src/app/[locale]/(viewer)/viewer/@books/_page.tsx
+++ b/src/app/[locale]/(viewer)/viewer/@books/_page.tsx
@@ -1,26 +1,30 @@
 import { Unauthorized } from "@/components/card/unauthorized";
 import { CountBadge } from "@/components/count-badge";
-import { ViewerStack } from "@/components/stack/viewer-stack";
+import { PreviewStack } from "@/components/stack/preview-stack";
 import { hasViewerAdminPermission } from "@/features/auth/utils/session";
 import {
 	getAllStaticBooks,
 	getStaticBooksCount,
 } from "@/features/viewer/actions/static-books";
 
-const path = "books";
+const basePath = "books";
 
 export async function SuspensePage() {
 	const hasAdminPermission = await hasViewerAdminPermission();
 
 	const totalImages = await getStaticBooksCount();
-	const images = await getAllStaticBooks();
+	const previewCardData = await getAllStaticBooks();
 
 	return (
 		<>
 			{hasAdminPermission ? (
 				<>
 					<CountBadge label="totalBooks" total={totalImages} />
-					<ViewerStack imageType="webp" images={images} path={path} />
+					<PreviewStack
+						basePath={basePath}
+						imageType="webp"
+						previewCardData={previewCardData}
+					/>
 				</>
 			) : (
 				<Unauthorized />

--- a/src/app/[locale]/(viewer)/viewer/@contents/_page.tsx
+++ b/src/app/[locale]/(viewer)/viewer/@contents/_page.tsx
@@ -1,27 +1,31 @@
 import { Unauthorized } from "@/components/card/unauthorized";
 import { CountBadge } from "@/components/count-badge";
-import { ViewerStack } from "@/components/stack/viewer-stack";
+import { PreviewStack } from "@/components/stack/preview-stack";
 import { hasViewerAdminPermission } from "@/features/auth/utils/session";
 import {
 	getAllStaticContents,
 	getStaticContentsCount,
 } from "@/features/viewer/actions/static-contents";
 
-const path = "contents";
+const basePath = "contents";
 
 export async function SuspensePage() {
 	const hasAdminPermission = await hasViewerAdminPermission();
 
 	const totalImages = await getStaticContentsCount();
 
-	const images = await getAllStaticContents();
+	const previewCardData = await getAllStaticContents();
 
 	return (
 		<>
 			{hasAdminPermission ? (
 				<>
 					<CountBadge label="totalContents" total={totalImages} />
-					<ViewerStack imageType="svg" images={images} path={path} />
+					<PreviewStack
+						basePath={basePath}
+						imageType="svg"
+						previewCardData={previewCardData}
+					/>
 				</>
 			) : (
 				<Unauthorized />

--- a/src/components/body/viewer-body.tsx
+++ b/src/components/body/viewer-body.tsx
@@ -2,10 +2,11 @@
 import Loading from "@/components/loading";
 import { markdownToReact } from "@/features/viewer/utils/markdown-to-react";
 import { useQuery } from "@tanstack/react-query";
+import { ReactNode } from "react";
 
-type Props = { markdown: string };
+type Props = { children?: ReactNode; markdown: string };
 
-export function ViewerBody({ markdown }: Props) {
+export function ViewerBody({ children, markdown }: Props) {
 	const { data, isLoading } = useQuery({
 		queryKey: ["viewerBody", markdown.slice(0, 10)],
 		queryFn: async () => await markdownToReact(markdown),
@@ -16,7 +17,8 @@ export function ViewerBody({ markdown }: Props) {
 	if (isLoading) return <Loading />;
 
 	return (
-		<div className="prose prose-sm mx-auto max-w-5xl px-4 py-2 dark:prose-invert">
+		<div className="prose prose-sm mx-auto max-w-5xl px-4 py-2 dark:prose-invert space-y-8">
+			{children}
 			{data}
 		</div>
 	);

--- a/src/components/card/preview-card.stories.tsx
+++ b/src/components/card/preview-card.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ViewerPreview } from "./viewer-preview";
+import { PreviewCard } from "./preview-card";
 
 const meta = {
-	title: "Components/Card/ViewerPreview",
-	component: ViewerPreview,
+	title: "Components/Card/previewCard",
+	component: PreviewCard,
 	parameters: { layout: "centered" },
 	tags: ["autodocs"],
-} satisfies Meta<typeof ViewerPreview>;
+} satisfies Meta<typeof PreviewCard>;
 
 export default meta;
 
@@ -21,11 +21,12 @@ const uint8ArrayImage = encoder.encode(svg);
 
 export const Default: Story = {
 	args: {
-		image: {
+		previewCardData: {
+			href: "0011223344",
 			title: "sample title",
 			uint8ArrayImage,
 		},
-		path: "/example",
+		basePath: "/example",
 		imageType: "svg",
 	},
 };

--- a/src/components/card/preview-card.tsx
+++ b/src/components/card/preview-card.tsx
@@ -7,25 +7,25 @@ import NextImage from "next/image";
 
 export type ImageType = "webp" | "svg";
 
-export type Image = {
+export type PreviewCardData = {
+	href: string;
 	title: string;
 	uint8ArrayImage: Uint8Array;
 };
 
 type Props = {
-	image: Image;
+	basePath: string;
 	imageType: ImageType;
-	path: string;
+	previewCardData: PreviewCardData;
 };
 
-export function ViewerPreview({ image, path, imageType }: Props) {
-	const { title, uint8ArrayImage } = image;
-	const href = `${path}/${title}` as Route;
+export function PreviewCard({ basePath, previewCardData, imageType }: Props) {
+	const { title, href, uint8ArrayImage } = previewCardData;
 
 	const src = convertUint8ArrayToImgSrc(uint8ArrayImage, imageType);
 
 	return (
-		<Link href={href}>
+		<Link href={`${basePath}/${href}` as Route}>
 			<Card className="flex h-full flex-col justify-evenly">
 				<CardHeader>
 					<CardTitle className="text-center">{title}</CardTitle>

--- a/src/components/stack/preview-stack.stories.tsx
+++ b/src/components/stack/preview-stack.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { NextIntlClientProvider } from "next-intl";
-import { ViewerStack } from "./viewer-stack";
+import { PreviewStack } from "./preview-stack";
 
 const meta = {
-	title: "Components/Stack/ViewerStack",
-	component: ViewerStack,
+	title: "Components/Stack/PreviewStack",
+	component: PreviewStack,
 	parameters: { layout: "centered" },
 	tags: ["autodocs"],
-} satisfies Meta<typeof ViewerStack>;
+} satisfies Meta<typeof PreviewStack>;
 
 export default meta;
 
@@ -20,28 +20,40 @@ const svg = `
 const encoder = new TextEncoder();
 const uint8ArrayImage = encoder.encode(svg);
 
-const images = [
+const previewCardData = [
 	{
+		isbn: "1111111111",
+		href: "/example/1111111111",
 		title: "sample title 1",
 		uint8ArrayImage,
 	},
 	{
+		isbn: "2222222222",
+		href: "/example/2222222222",
 		title: "sample title 2",
 		uint8ArrayImage,
 	},
 	{
+		isbn: "3333333333",
+		href: "/example/3333333333",
 		title: "sample title 3",
 		uint8ArrayImage,
 	},
 	{
+		isbn: "4444444444",
+		href: "/example/4444444444",
 		title: "sample title 4",
 		uint8ArrayImage,
 	},
 	{
+		isbn: "5555555555",
+		href: "/example/5555555555",
 		title: "sample title 5",
 		uint8ArrayImage,
 	},
 	{
+		isbn: "6666666666",
+		href: "/example/6666666666",
 		title: "sample title 6",
 		uint8ArrayImage,
 	},
@@ -51,16 +63,20 @@ const imageType = "svg";
 
 export const Default: Story = {
 	args: {
-		images,
-		path,
+		previewCardData,
+		basePath: path,
 		imageType,
 	},
-	render: () => (
+	render: (args) => (
 		<NextIntlClientProvider
 			locale="ja"
 			messages={{ label: { search: "検索" } }}
 		>
-			<ViewerStack imageType={imageType} images={images} path={path} />
+			<PreviewStack
+				imageType={imageType}
+				basePath={args.basePath}
+				previewCardData={args.previewCardData}
+			/>
 		</NextIntlClientProvider>
 	),
 };

--- a/src/components/stack/preview-stack.stories.tsx
+++ b/src/components/stack/preview-stack.stories.tsx
@@ -73,8 +73,8 @@ export const Default: Story = {
 			messages={{ label: { search: "検索" } }}
 		>
 			<PreviewStack
-				imageType={imageType}
 				basePath={args.basePath}
+				imageType={imageType}
 				previewCardData={args.previewCardData}
 			/>
 		</NextIntlClientProvider>

--- a/src/components/stack/preview-stack.tsx
+++ b/src/components/stack/preview-stack.tsx
@@ -1,9 +1,9 @@
 "use client";
 import {
-	Image,
 	ImageType,
-	ViewerPreview,
-} from "@/components/card/viewer-preview";
+	PreviewCard,
+	PreviewCardData,
+} from "@/components/card/preview-card";
 import { Input } from "@/components/ui/input";
 import { useTranslations } from "next-intl";
 import { useTransitionRouter } from "next-view-transitions";
@@ -14,12 +14,12 @@ import { useDebouncedCallback } from "use-debounce";
 const PARAM_NAME = "q";
 
 type Props = {
-	images: Image[];
+	basePath: string;
 	imageType: ImageType;
-	path: string;
+	previewCardData: PreviewCardData[];
 };
 
-export function ViewerStack({ images, path, imageType }: Props) {
+export function PreviewStack({ previewCardData, basePath, imageType }: Props) {
 	// TODO: use queryを利用してデータのキャッシュを行う
 
 	const router = useTransitionRouter();
@@ -27,17 +27,17 @@ export function ViewerStack({ images, path, imageType }: Props) {
 	const [searchTerm, setSearchTerm] = useState(
 		searchParams.get(PARAM_NAME) ?? "",
 	);
-	const [searchResults, setSearchResults] = useState(images);
+	const [searchResults, setSearchResults] = useState(previewCardData);
 
 	const fetchSearchResults = useCallback(
 		async (searchString: string) => {
-			if (searchString === "") setSearchResults(images);
+			if (searchString === "") setSearchResults(previewCardData);
 			else
 				setSearchResults(
-					images.filter((image) => image.title.includes(searchString)),
+					previewCardData.filter((image) => image.title.includes(searchString)),
 				);
 		},
-		[images],
+		[previewCardData],
 	);
 
 	const debouncedSearch = useDebouncedCallback(async (searchString: string) => {
@@ -67,13 +67,13 @@ export function ViewerStack({ images, path, imageType }: Props) {
 				value={searchTerm}
 			/>
 			<div className="my-2 grid grid-cols-2 items-stretch gap-4 sm:grid-cols-3 lg:grid-cols-4">
-				{searchResults.map((image) => {
+				{searchResults.map((searchResult) => {
 					return (
-						<ViewerPreview
-							image={image}
+						<PreviewCard
+							basePath={basePath}
 							imageType={imageType}
-							key={image.title}
-							path={path}
+							key={searchResult.title}
+							previewCardData={searchResult}
 						/>
 					);
 				})}

--- a/src/features/ai/actions/fetch-knowledge.ts
+++ b/src/features/ai/actions/fetch-knowledge.ts
@@ -54,12 +54,3 @@ export async function fetchContentByTitle(title: string) {
 		cacheStrategy: { ttl: 400, tags: ["staticContents"] },
 	});
 }
-
-// Fetch a specific book by title
-export async function fetchBookByTitle(title: string) {
-	return await prisma.staticBooks.findUnique({
-		where: { title },
-		select: { title: true, markdown: true },
-		cacheStrategy: { ttl: 400, tags: ["staticBooks"] },
-	});
-}

--- a/src/features/viewer/actions/static-books.ts
+++ b/src/features/viewer/actions/static-books.ts
@@ -2,10 +2,15 @@ import prisma from "@/prisma";
 import { cache } from "react";
 
 const _getAllStaticBooks = async () => {
-	return await prisma.staticBooks.findMany({
-		select: { title: true, uint8ArrayImage: true },
+	const books = await prisma.staticBooks.findMany({
+		select: { ISBN: true, title: true, uint8ArrayImage: true },
 		cacheStrategy: { ttl: 400, tags: ["staticBooks"] },
 	});
+	return books.map((book) => ({
+		title: book.title,
+		href: book.ISBN,
+		uint8ArrayImage: book.uint8ArrayImage,
+	}));
 };
 
 export const getAllStaticBooks = cache(_getAllStaticBooks);

--- a/src/features/viewer/actions/static-contents.ts
+++ b/src/features/viewer/actions/static-contents.ts
@@ -2,10 +2,16 @@ import prisma from "@/prisma";
 import { cache } from "react";
 
 const _getAllStaticContents = async () => {
-	return await prisma.staticContents.findMany({
+	const contents = await prisma.staticContents.findMany({
 		select: { title: true, uint8ArrayImage: true },
 		cacheStrategy: { ttl: 400, tags: ["staticContents"] },
 	});
+
+	return contents.map((content) => ({
+		title: content.title,
+		href: content.title,
+		uint8ArrayImage: content.uint8ArrayImage,
+	}));
 };
 
 export const getAllStaticContents = cache(_getAllStaticContents);

--- a/src/features/viewer/utils/convert.ts
+++ b/src/features/viewer/utils/convert.ts
@@ -1,4 +1,4 @@
-import { ImageType } from "@/components/card/viewer-preview";
+import { ImageType } from "@/components/card/preview-card";
 import { UnexpectedError } from "@/error-classes";
 
 const bufferToBase64 = (buffer: Uint8Array) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 書籍詳細ページでGoogle Booksのメタデータ（タイトル、サブタイトル、説明、著者、サムネイル画像、リンク）を管理者向けにカードUIで表示。
  - 外部画像ソースとして「books.google.com」からの画像表示に対応。

- **改善**
  - 書籍・コンテンツ一覧のプレビュー表示を新しい「PreviewCard」「PreviewStack」コンポーネントに刷新し、リンク先やデータ構造を統一。
  - 書籍データ取得時にISBNをリンク用プロパティとして追加。
  - コンポーネントのprops構造や型名をわかりやすく整理。

- **バグ修正**
  - 書籍詳細ページのメタデータ生成でURLデコードを廃止し、スラッグをそのまま利用するよう修正。

- **ドキュメント**
  - Storybookのストーリーを新コンポーネント・新プロパティに対応。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->