### PR TITLE
test: add more storybooks

### DIFF
--- a/src/components/card/small-card.stories.tsx
+++ b/src/components/card/small-card.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SmallCard } from "./small-card";
+
+const meta = {
+	title: "Components/Card/SmallCard",
+	component: SmallCard,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof SmallCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		id: 1,
+		title: "Sample News Title",
+		quote: "This is a sample quote or description for the news item.",
+		url: "https://example.com",
+		category: "Tech",
+		showDeleteButton: false,
+	},
+};
+
+export const WithDeleteButton: Story = {
+	args: {
+		id: 2,
+		title: "News with Delete Button",
+		quote: "This news item has a delete button visible.",
+		url: "https://example.com",
+		category: "News",
+		showDeleteButton: true,
+	},
+};
+
+export const WithoutCategory: Story = {
+	args: {
+		id: 3,
+		title: "News without Category",
+		quote: "This news item doesn't have a category.",
+		url: "https://example.com",
+		showDeleteButton: false,
+	},
+};
+
+export const WithoutQuote: Story = {
+	args: {
+		id: 4,
+		title: "News without Quote",
+		quote: null,
+		url: "https://example.com",
+		category: "General",
+		showDeleteButton: false,
+	},
+};
+
+export const LongTitle: Story = {
+	args: {
+		id: 5,
+		title:
+			"This is a very long news title that might wrap to multiple lines to test how the component handles longer text content",
+		quote:
+			"This is also a longer quote to test how the component handles longer description text that might be truncated.",
+		url: "https://example.com",
+		category: "Long Content",
+		showDeleteButton: false,
+	},
+};

--- a/src/components/card/small-card.tsx
+++ b/src/components/card/small-card.tsx
@@ -1,4 +1,5 @@
 import { Link } from "next-view-transitions";
+import { DeleteButtonWithModal } from "@/components/delete-button-with-modal";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -7,11 +8,12 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import { DeleteNewsButton } from "@/features/news/components/delete-news-button";
+import { ServerAction } from "@/types";
 import { validateUrl } from "@/utils/validate-url";
 
 type Props = {
 	category?: string;
+	deleteAction?: (id: number) => Promise<ServerAction<number>>;
 	id: number;
 	quote: string | null;
 	showDeleteButton: boolean;
@@ -21,6 +23,7 @@ type Props = {
 
 export function SmallCard({
 	id,
+	deleteAction,
 	title,
 	quote,
 	url,
@@ -32,7 +35,13 @@ export function SmallCard({
 	return (
 		<Link data-testid={`small-card-${id}`} href={validatedUrl} target="_blank">
 			<Card className="relative hover:bg-secondary">
-				{showDeleteButton && <DeleteNewsButton id={id} title={title} />}
+				{showDeleteButton && deleteAction !== undefined && (
+					<DeleteButtonWithModal
+						deleteAction={deleteAction}
+						id={id}
+						title={title}
+					/>
+				)}
 				<CardHeader>
 					<div className="flex gap-4">
 						<Badge>{id}</Badge>

--- a/src/components/count-badge.stories.tsx
+++ b/src/components/count-badge.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import { CountBadge } from "./count-badge";
+
+const meta = {
+	title: "Components/CountBadge",
+	component: CountBadge,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof CountBadge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: "news",
+		total: 42,
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{ label: { news: "ニュース" } }}
+		>
+			<CountBadge label={args.label} total={args.total} />
+		</NextIntlClientProvider>
+	),
+};
+
+export const LargeCount: Story = {
+	args: {
+		label: "contents",
+		total: 1234,
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{ label: { contents: "コンテンツ" } }}
+		>
+			<CountBadge label={args.label} total={args.total} />
+		</NextIntlClientProvider>
+	),
+};
+
+export const ZeroCount: Story = {
+	args: {
+		label: "images",
+		total: 0,
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{ label: { images: "画像" } }}
+		>
+			<CountBadge label={args.label} total={args.total} />
+		</NextIntlClientProvider>
+	),
+};

--- a/src/components/delete-button-with-modal.stories.tsx
+++ b/src/components/delete-button-with-modal.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "@storybook/test";
+import { NextIntlClientProvider } from "next-intl";
+import { DeleteButtonWithModal } from "./delete-button-with-modal";
+
+const meta = {
+	title: "Components/DeleteNewsButtonWithModal",
+	component: DeleteButtonWithModal,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof DeleteButtonWithModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		id: 1,
+		title: "Sample News Title",
+		deleteAction: fn(),
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{
+				label: {
+					delete: "削除",
+					confirmDelete: "本当に削除しますか？",
+					cancel: "キャンセル",
+				},
+			}}
+		>
+			<DeleteButtonWithModal
+				deleteAction={args.deleteAction}
+				id={args.id}
+				title={args.title}
+			/>
+		</NextIntlClientProvider>
+	),
+};
+
+export const LongTitle: Story = {
+	args: {
+		id: 2,
+		title:
+			"This is a very long news title that might wrap to multiple lines to test how the component handles longer text content in the dialog",
+		deleteAction: fn(),
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{
+				label: {
+					delete: "削除",
+					confirmDelete: "本当に削除しますか？",
+					cancel: "キャンセル",
+				},
+			}}
+		>
+			<DeleteButtonWithModal
+				deleteAction={args.deleteAction}
+				id={args.id}
+				title={args.title}
+			/>
+		</NextIntlClientProvider>
+	),
+};
+
+export const ShortTitle: Story = {
+	args: {
+		id: 3,
+		title: "Short",
+		deleteAction: fn(),
+	},
+	render: (args) => (
+		<NextIntlClientProvider
+			locale="ja"
+			messages={{
+				label: {
+					delete: "削除",
+					confirmDelete: "本当に削除しますか？",
+					cancel: "キャンセル",
+				},
+			}}
+		>
+			<DeleteButtonWithModal
+				deleteAction={args.deleteAction}
+				id={args.id}
+				title={args.title}
+			/>
+		</NextIntlClientProvider>
+	),
+};

--- a/src/components/delete-button-with-modal.tsx
+++ b/src/components/delete-button-with-modal.tsx
@@ -12,14 +12,15 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { deleteNews } from "@/features/news/actions/delete-news";
+import { ServerAction } from "@/types";
 
 type Props = {
+	deleteAction: (id: number) => Promise<ServerAction<number>>;
 	id: number;
 	title: string;
 };
 
-export function DeleteNewsButton({ id, title }: Props) {
+export function DeleteButtonWithModal({ id, title, deleteAction }: Props) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
 
@@ -29,7 +30,7 @@ export function DeleteNewsButton({ id, title }: Props) {
 	const handleDelete = async () => {
 		try {
 			setIsDeleting(true);
-			const response = await deleteNews(id);
+			const response = await deleteAction(id);
 			toast(message(response.message));
 			setIsOpen(false);
 		} catch {

--- a/src/components/loading.stories.tsx
+++ b/src/components/loading.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import Loading from "./loading";
+
+const meta = {
+	title: "Components/Loading",
+	component: Loading,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/stack/card-stack.stories.tsx
+++ b/src/components/stack/card-stack.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import { CardStack } from "./card-stack";
+
+const meta = {
+	title: "Components/Stack/CardStack",
+	component: CardStack,
+	parameters: { layout: "fullscreen" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof CardStack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const mockData = [
+	{
+		id: 1,
+		title: "First News Item",
+		quote: "This is the first news item with a quote.",
+		url: "https://example.com/1",
+		category: "Tech",
+	},
+	{
+		id: 2,
+		title: "Second News Item",
+		quote: "This is the second news item.",
+		url: "https://example.com/2",
+		category: "News",
+	},
+	{
+		id: 3,
+		title: "Third News Item",
+		quote: null,
+		url: "https://example.com/3",
+		category: "General",
+	},
+];
+
+export const Default: Story = {
+	args: {
+		data: mockData,
+		showDeleteButton: false,
+	},
+};
+
+export const WithDeleteButton: Story = {
+	args: {
+		data: mockData,
+		showDeleteButton: true,
+	},
+};
+
+export const EmptyData: Story = {
+	args: {
+		data: [],
+		showDeleteButton: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider
+				locale="ja"
+				messages={{
+					label: {
+						delete: "削除",
+						confirmDelete: "本当に削除しますか？",
+						cancel: "キャンセル",
+					},
+				}}
+			>
+				<CardStack data={args.data} showDeleteButton={args.showDeleteButton} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const SingleItem: Story = {
+	args: {
+		data: [mockData[0]],
+		showDeleteButton: false,
+	},
+};
+
+export const ManyItems: Story = {
+	args: {
+		data: [
+			...mockData,
+			{
+				id: 4,
+				title: "Fourth News Item",
+				quote: "This is the fourth news item to test grid layout.",
+				url: "https://example.com/4",
+				category: "Sports",
+			},
+			{
+				id: 5,
+				title: "Fifth News Item",
+				quote:
+					"This is the fifth news item with a longer description to test text truncation and wrapping behavior.",
+				url: "https://example.com/5",
+			},
+		],
+		showDeleteButton: false,
+	},
+};

--- a/src/components/stack/card-stack.tsx
+++ b/src/components/stack/card-stack.tsx
@@ -2,6 +2,7 @@
 import { SmallCard } from "@/components/card/small-card";
 import { StatusCodeView } from "@/components/card/status-code-view";
 import { CardStackSkeleton } from "@/components/stack/card-stack-skeleton";
+import { ServerAction } from "@/types";
 
 type Props = {
 	data: {
@@ -11,10 +12,11 @@ type Props = {
 		title: string;
 		url: string;
 	}[];
+	deleteAction?: (id: number) => Promise<ServerAction<number>>;
 	showDeleteButton: boolean;
 };
 
-export function CardStack({ data, showDeleteButton }: Props) {
+export function CardStack({ data, showDeleteButton, deleteAction }: Props) {
 	if (data === undefined) return <CardStackSkeleton />;
 	if (data.length === 0) return <StatusCodeView statusCode="204" />;
 
@@ -24,6 +26,7 @@ export function CardStack({ data, showDeleteButton }: Props) {
 				return (
 					<SmallCard
 						category={d.category}
+						deleteAction={deleteAction}
 						id={d.id}
 						key={d.id}
 						quote={d.quote}

--- a/src/features/ai/components/search-form.stories.tsx
+++ b/src/features/ai/components/search-form.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "@storybook/test";
+import { NextIntlClientProvider } from "next-intl";
+import { SearchForm } from "./search-form";
+
+const meta = {
+	title: "Features/AI/SearchForm",
+	component: SearchForm,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof SearchForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		onSearch: fn(),
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchForm onSearch={args.onSearch} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const WithInitialQuery: Story = {
+	args: {
+		initialQuery: "sample search query",
+		onSearch: fn(),
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchForm initialQuery={args.initialQuery} onSearch={args.onSearch} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const EmptyInitialQuery: Story = {
+	args: {
+		initialQuery: "",
+		onSearch: fn(),
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchForm initialQuery={args.initialQuery} onSearch={args.onSearch} />
+			</NextIntlClientProvider>
+		);
+	},
+};

--- a/src/features/ai/components/search-results.stories.tsx
+++ b/src/features/ai/components/search-results.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import type { SearchResult } from "@/features/ai/actions/ai-search";
+import { SearchResults } from "./search-results";
+
+const meta = {
+	title: "Features/AI/SearchResults",
+	component: SearchResults,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof SearchResults>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const mockResults: SearchResult[] = [
+	{
+		id: "1",
+		title: "Introduction to React",
+		content: "React is a JavaScript library for building user interfaces...",
+		aiSummary:
+			"This content covers the basics of React including components, state, and props.",
+		type: "content",
+		relevanceScore: 0.95,
+	},
+	{
+		id: "2",
+		title: "Advanced TypeScript Patterns",
+		content: "TypeScript provides powerful type system features...",
+		aiSummary:
+			"Learn about advanced TypeScript patterns including conditional types, mapped types, and utility types.",
+		type: "book",
+		relevanceScore: 0.87,
+	},
+	{
+		id: "3",
+		title: "Modern Web Development",
+		content: "Web development has evolved significantly...",
+		aiSummary:
+			"This book covers modern web development practices including responsive design, performance optimization, and accessibility.",
+		type: "book",
+		relevanceScore: 0.72,
+	},
+];
+
+export const Default: Story = {
+	args: {
+		results: mockResults,
+		isLoading: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		results: [],
+		isLoading: true,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const NoResults: Story = {
+	args: {
+		results: [],
+		isLoading: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const SingleResult: Story = {
+	args: {
+		results: [mockResults[0]],
+		isLoading: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const ContentOnly: Story = {
+	args: {
+		results: [mockResults[0]],
+		isLoading: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const BookOnly: Story = {
+	args: {
+		results: [mockResults[1]],
+		isLoading: false,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<SearchResults isLoading={args.isLoading} results={args.results} />
+			</NextIntlClientProvider>
+		);
+	},
+};

--- a/src/features/dump/components/add-form-skeleton.stories.tsx
+++ b/src/features/dump/components/add-form-skeleton.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import { AddFormSkeleton } from "./add-form-skeleton";
+
+const meta = {
+	title: "Features/Dump/AddFormSkeleton",
+	component: AddFormSkeleton,
+	parameters: { layout: "centered" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof AddFormSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {},
+	render: () => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<AddFormSkeleton />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const WithCategory: Story = {
+	args: {
+		showCategory: true,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<AddFormSkeleton showCategory={args.showCategory} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const WithSubmitButton: Story = {
+	args: {
+		showSubmitButton: true,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<AddFormSkeleton showSubmitButton={args.showSubmitButton} />
+			</NextIntlClientProvider>
+		);
+	},
+};
+
+export const WithCategoryAndSubmitButton: Story = {
+	args: {
+		showCategory: true,
+		showSubmitButton: true,
+	},
+	render: (args) => {
+		return (
+			<NextIntlClientProvider locale="ja">
+				<AddFormSkeleton
+					showCategory={args.showCategory}
+					showSubmitButton={args.showSubmitButton}
+				/>
+			</NextIntlClientProvider>
+		);
+	},
+};

--- a/src/features/news/components/news-stack.tsx
+++ b/src/features/news/components/news-stack.tsx
@@ -3,6 +3,7 @@ import "server-only";
 import { StatusCodeView } from "@/components/card/status-code-view";
 import { CardStack } from "@/components/stack/card-stack";
 import { getSelfId } from "@/features/auth/utils/session";
+import { deleteNews } from "@/features/news/actions/delete-news";
 import { loggerError } from "@/pino";
 import prisma from "@/prisma";
 
@@ -31,7 +32,13 @@ export async function NewsStack() {
 				category: d.Category.name,
 			};
 		});
-		return <CardStack data={unexportedNews} showDeleteButton />;
+		return (
+			<CardStack
+				data={unexportedNews}
+				deleteAction={deleteNews}
+				showDeleteButton
+			/>
+		);
 	} catch (error) {
 		loggerError(
 			"unexpected",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Storybookに複数のコンポーネント（SmallCard、CountBadge、DeleteButtonWithModal、Loading、CardStack、SearchForm、SearchResults、AddFormSkeleton）のストーリーを追加し、さまざまな状態やバリエーションを確認できるようになりました。
  * CardStackおよびSmallCardで削除アクション機能が追加され、削除ボタンがより柔軟に動作するようになりました。
  * NewsStackで削除ボタンが実際の削除アクションと連携するようになりました。

* **改善**
  * DeleteNewsButtonがDeleteButtonWithModalにリネームされ、削除アクションの受け渡しが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->