### PR TITLE
feat: add duplicate revert function

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -55,7 +55,7 @@ const preview = {
 						updated: "更新が完了しました。",
 						unexpected: "予期せぬエラーが発生しました。",
 						pushoverSend: "ログの送信でエラーが発生しました。",
-						prismaDuplicated: "すでに登録されているため登録できません。",
+						duplicated: "すでに登録されているため登録できません。",
 						prismaUnexpected:
 							"データベースへの書き込み時にエラーが発生しました。",
 						unauthorized: "認証されていません。",

--- a/messages/en.json
+++ b/messages/en.json
@@ -43,7 +43,7 @@
 		"updated": "Updated successfully.",
 		"unexpected": "Unexpected error occurred.",
 		"pushoverSend": "Failed to send logs.",
-		"prismaDuplicated": "Duplicated record.",
+		"duplicated": "Duplicated record.",
 		"prismaUnexpected": "Failed to write to database.",
 		"unauthorized": "Unauthorized error.",
 		"notAllowed": "Not allowed error.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -43,7 +43,7 @@
 		"updated": "更新が完了しました。",
 		"unexpected": "予期せぬエラーが発生しました。",
 		"pushoverSend": "ログの送信でエラーが発生しました。",
-		"prismaDuplicated": "すでに登録されているため登録できません。",
+		"duplicated": "すでに登録されているため登録できません。",
 		"prismaUnexpected": "データベースへの書き込み時にエラーが発生しました。",
 		"unauthorized": "認証されていません。",
 		"notAllowed": "操作が許可されていません。",

--- a/src/common/components/forms/fields/form-dropdown-input.tsx
+++ b/src/common/components/forms/fields/form-dropdown-input.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type RefObject } from "react";
+import { type ComponentProps, type RefObject, useEffect } from "react";
 import { Button } from "@/common/components/ui/button";
 import {
 	DropdownMenu,
@@ -8,6 +8,7 @@ import {
 } from "@/common/components/ui/dropdown-menu";
 import { Input } from "@/common/components/ui/input";
 import { Label } from "@/common/components/ui/label";
+import { useFormValues } from "../generic-form-wrapper";
 
 type Props = {
 	label: string;
@@ -23,19 +24,34 @@ export function FormDropdownInput({
 	options,
 	triggerIcon,
 	inputRef,
+	defaultValue,
 	...inputProps
 }: Props) {
+	const formValues = useFormValues();
+	const preservedValue = formValues[inputProps.name || htmlFor];
+
 	const handleSelectedValueChange = (value: string) => {
 		if (inputRef?.current) {
 			inputRef.current.value = value;
 		}
 	};
 
+	useEffect(() => {
+		if (preservedValue && inputRef?.current) {
+			inputRef.current.value = preservedValue;
+		}
+	}, [preservedValue, inputRef]);
+
 	return (
 		<div className="space-y-1">
 			<Label htmlFor={htmlFor}>{label}</Label>
 			<div className="flex">
-				<Input id={htmlFor} ref={inputRef} {...inputProps} />
+				<Input
+					defaultValue={preservedValue || defaultValue}
+					id={htmlFor}
+					ref={inputRef}
+					{...inputProps}
+				/>
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
 						<Button variant="ghost">{triggerIcon}</Button>

--- a/src/common/components/forms/fields/form-input-with-button.tsx
+++ b/src/common/components/forms/fields/form-input-with-button.tsx
@@ -1,7 +1,8 @@
-import { type ComponentProps, type RefObject } from "react";
+import { type ComponentProps, type RefObject, useEffect } from "react";
 import { Button } from "@/common/components/ui/button";
 import { Input } from "@/common/components/ui/input";
 import { Label } from "@/common/components/ui/label";
+import { useFormValues } from "../generic-form-wrapper";
 
 type Props = {
 	label: string;
@@ -19,13 +20,28 @@ export function FormInputWithButton({
 	onButtonClick,
 	inputRef,
 	buttonTestId,
+	defaultValue,
 	...inputProps
 }: Props) {
+	const formValues = useFormValues();
+	const preservedValue = formValues[inputProps.name || htmlFor];
+
+	useEffect(() => {
+		if (preservedValue && inputRef?.current) {
+			inputRef.current.value = preservedValue;
+		}
+	}, [preservedValue, inputRef]);
+
 	return (
 		<div className="space-y-1">
 			<Label htmlFor={htmlFor}>{label}</Label>
 			<div className="flex">
-				<Input id={htmlFor} ref={inputRef} {...inputProps} />
+				<Input
+					defaultValue={preservedValue || defaultValue}
+					id={htmlFor}
+					ref={inputRef}
+					{...inputProps}
+				/>
 				<Button
 					data-testid={buttonTestId}
 					onClick={onButtonClick}

--- a/src/common/components/forms/fields/form-input.tsx
+++ b/src/common/components/forms/fields/form-input.tsx
@@ -1,17 +1,30 @@
 import { type ComponentProps } from "react";
 import { Input } from "@/common/components/ui/input";
 import { Label } from "@/common/components/ui/label";
+import { useFormValues } from "../generic-form-wrapper";
 
 type Props = {
 	label: string;
 	htmlFor: string;
 } & ComponentProps<typeof Input>;
 
-export function FormInput({ label, htmlFor, ...inputProps }: Props) {
+export function FormInput({
+	label,
+	htmlFor,
+	defaultValue,
+	...inputProps
+}: Props) {
+	const formValues = useFormValues();
+	const preservedValue = formValues[inputProps.name || htmlFor];
+
 	return (
 		<div className="space-y-1">
 			<Label htmlFor={htmlFor}>{label}</Label>
-			<Input id={htmlFor} {...inputProps} />
+			<Input
+				defaultValue={preservedValue || defaultValue}
+				id={htmlFor}
+				{...inputProps}
+			/>
 		</div>
 	);
 }

--- a/src/common/components/forms/fields/form-textarea.tsx
+++ b/src/common/components/forms/fields/form-textarea.tsx
@@ -1,17 +1,30 @@
 import { type ComponentProps } from "react";
 import { Label } from "@/common/components/ui/label";
 import { Textarea } from "@/common/components/ui/textarea";
+import { useFormValues } from "../generic-form-wrapper";
 
 type Props = {
 	label: string;
 	htmlFor: string;
 } & ComponentProps<typeof Textarea>;
 
-export function FormTextarea({ label, htmlFor, ...textareaProps }: Props) {
+export function FormTextarea({
+	label,
+	htmlFor,
+	defaultValue,
+	...textareaProps
+}: Props) {
+	const formValues = useFormValues();
+	const preservedValue = formValues[textareaProps.name || htmlFor];
+
 	return (
 		<div className="space-y-1">
 			<Label htmlFor={htmlFor}>{label}</Label>
-			<Textarea id={htmlFor} {...textareaProps} />
+			<Textarea
+				defaultValue={preservedValue || defaultValue}
+				id={htmlFor}
+				{...textareaProps}
+			/>
 		</div>
 	);
 }

--- a/src/common/error/error-wrapper.test.ts
+++ b/src/common/error/error-wrapper.test.ts
@@ -94,17 +94,18 @@ describe("wrapServerSideErrorForClient", () => {
 
 		const result = await wrapServerSideErrorForClient(error);
 
-		expect(serverLogger.warn).toHaveBeenCalledWith(
+		expect(serverLogger.error).toHaveBeenCalledWith(
 			error.message,
 			{
 				caller: "wrapServerSideError",
-				status: 400, // Updated to appropriate status for known client errors
+				status: 500,
 			},
+			undefined,
 			{ notify: true },
 		);
 		expect(result).toEqual({
 			success: false,
-			message: "prismaDuplicated",
+			message: "prismaUnexpected",
 		});
 	});
 

--- a/src/common/error/error-wrapper.ts
+++ b/src/common/error/error-wrapper.ts
@@ -12,8 +12,22 @@ import {
 	UnexpectedError,
 } from "./error-classes";
 
+function formDataToRecord(
+	formData?: FormData,
+): Record<string, string> | undefined {
+	if (!formData) return undefined;
+	const record: Record<string, string> = {};
+	for (const [key, value] of formData.entries()) {
+		if (typeof value === "string") {
+			record[key] = value;
+		}
+	}
+	return record;
+}
+
 export async function wrapServerSideErrorForClient<T>(
 	error: unknown,
+	formData?: FormData,
 ): Promise<ServerAction> {
 	if (error instanceof PushoverError) {
 		serverLogger.error(
@@ -38,7 +52,11 @@ export async function wrapServerSideErrorForClient<T>(
 			status: 500 as const,
 		};
 		serverLogger.warn(error.message, context, { notify: true });
-		return { success: false, message: error.message };
+		return {
+			success: false,
+			message: error.message,
+			formData: formDataToRecord(formData),
+		};
 	}
 	if (error instanceof DuplicateError) {
 		const context = {
@@ -46,7 +64,11 @@ export async function wrapServerSideErrorForClient<T>(
 			status: 400 as const, // Bad request for duplicate resources
 		};
 		serverLogger.warn(error.message, context, { notify: true });
-		return { success: false, message: "prismaDuplicated" };
+		return {
+			success: false,
+			message: "duplicated",
+			formData: formDataToRecord(formData),
+		};
 	}
 	if (error instanceof AuthError) {
 		const context = {
@@ -64,7 +86,8 @@ export async function wrapServerSideErrorForClient<T>(
 		error instanceof Prisma.PrismaClientValidationError ||
 		error instanceof Prisma.PrismaClientUnknownRequestError ||
 		error instanceof Prisma.PrismaClientRustPanicError ||
-		error instanceof Prisma.PrismaClientInitializationError
+		error instanceof Prisma.PrismaClientInitializationError ||
+		error instanceof Prisma.PrismaClientKnownRequestError // 400 errors but should not occur due to domain service validation
 	) {
 		const context = {
 			caller: "wrapServerSideError",
@@ -72,14 +95,6 @@ export async function wrapServerSideErrorForClient<T>(
 		};
 		serverLogger.error(error.message, context, undefined, { notify: true });
 		return { success: false, message: "prismaUnexpected" };
-	}
-	if (error instanceof Prisma.PrismaClientKnownRequestError) {
-		const context = {
-			caller: "wrapServerSideError",
-			status: 400 as const, // Known client errors are typically 4xx
-		};
-		serverLogger.warn(error.message, context, { notify: true });
-		return { success: false, message: "prismaDuplicated" };
 	}
 
 	if (error instanceof Error) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,4 +1,5 @@
 export type ServerAction = {
 	message: string;
 	success: boolean;
+	formData?: Record<string, string>;
 };

--- a/src/domains/news/types.ts
+++ b/src/domains/news/types.ts
@@ -10,7 +10,7 @@ export type INewsCommandRepository = {
 };
 
 export type INewsQueryRepository = {
-	findByUrl(userId: string, url: string): Promise<{} | null>;
+	findByUrl(url: string, userId: string): Promise<{} | null>;
 	findMany(
 		userId: string,
 		status: Status,

--- a/src/features/books/actions/add-books.test.ts
+++ b/src/features/books/actions/add-books.test.ts
@@ -114,7 +114,7 @@ describe("addBooks", () => {
 
 		const result = await addBooks(formData);
 
-		expect(wrapServerSideErrorForClient).toHaveBeenCalledWith(error);
+		expect(wrapServerSideErrorForClient).toHaveBeenCalledWith(error, formData);
 		expect(result).toEqual({ success: false, message: "Error occurred" });
 	});
 });

--- a/src/features/books/actions/add-books.ts
+++ b/src/features/books/actions/add-books.ts
@@ -26,6 +26,6 @@ export async function addBooks(formData: FormData): Promise<ServerAction> {
 
 		return { success: true, message: "inserted" };
 	} catch (error) {
-		return await wrapServerSideErrorForClient(error);
+		return await wrapServerSideErrorForClient(error, formData);
 	}
 }

--- a/src/features/books/components/client/books-form-client.stories.tsx
+++ b/src/features/books/components/client/books-form-client.stories.tsx
@@ -18,7 +18,10 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
-		addBooks: async () => ({ message: "Book added successfully!" }),
+		addBooks: async () => ({
+			success: true,
+			message: "Book added successfully!",
+		}),
 	},
 };
 

--- a/src/features/books/components/client/books-form-client.tsx
+++ b/src/features/books/components/client/books-form-client.tsx
@@ -2,9 +2,10 @@
 import { useTranslations } from "next-intl";
 import { FormInput } from "@/common/components/forms/fields/form-input";
 import { GenericFormWrapper } from "@/common/components/forms/generic-form-wrapper";
+import type { ServerAction } from "@/common/types";
 
 type Props = {
-	addBooks: (formData: FormData) => Promise<{ message: string }>;
+	addBooks: (formData: FormData) => Promise<ServerAction>;
 };
 
 export function BooksFormClient({ addBooks }: Props) {

--- a/src/features/contents/actions/add-contents.ts
+++ b/src/features/contents/actions/add-contents.ts
@@ -32,6 +32,6 @@ export async function addContents(formData: FormData): Promise<ServerAction> {
 
 		return { success: true, message: "inserted" };
 	} catch (error) {
-		return await wrapServerSideErrorForClient(error);
+		return await wrapServerSideErrorForClient(error, formData);
 	}
 }

--- a/src/features/contents/components/client/contents-form-client.tsx
+++ b/src/features/contents/components/client/contents-form-client.tsx
@@ -3,9 +3,10 @@ import { useTranslations } from "next-intl";
 import { FormInput } from "@/common/components/forms/fields/form-input";
 import { FormTextarea } from "@/common/components/forms/fields/form-textarea";
 import { GenericFormWrapper } from "@/common/components/forms/generic-form-wrapper";
+import type { ServerAction } from "@/common/types";
 
 type Props = {
-	addContents: (formData: FormData) => Promise<{ message: string }>;
+	addContents: (formData: FormData) => Promise<ServerAction>;
 };
 
 export function ContentsFormClient({ addContents }: Props) {

--- a/src/features/images/actions/add-image.test.ts
+++ b/src/features/images/actions/add-image.test.ts
@@ -100,6 +100,7 @@ describe("addImage", () => {
 		expect(result).toEqual({
 			success: false,
 			message: "invalidFileFormat",
+			formData: {},
 		});
 	});
 
@@ -120,6 +121,7 @@ describe("addImage", () => {
 		expect(result).toEqual({
 			success: false,
 			message: "invalidFileFormat",
+			formData: {},
 		});
 	});
 
@@ -136,6 +138,7 @@ describe("addImage", () => {
 		expect(result).toEqual({
 			success: false,
 			message: "unexpected",
+			formData: {},
 		});
 	});
 });

--- a/src/features/images/actions/add-image.ts
+++ b/src/features/images/actions/add-image.ts
@@ -38,6 +38,6 @@ export async function addImage(formData: FormData): Promise<ServerAction> {
 
 		return { success: true, message: "inserted" };
 	} catch (error) {
-		return await wrapServerSideErrorForClient(error);
+		return await wrapServerSideErrorForClient(error, formData);
 	}
 }

--- a/src/features/images/components/client/image-form-client.tsx
+++ b/src/features/images/components/client/image-form-client.tsx
@@ -3,9 +3,10 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { FormFileInput } from "@/common/components/forms/fields/form-file-input";
 import { GenericFormWrapper } from "@/common/components/forms/generic-form-wrapper";
+import type { ServerAction } from "@/common/types";
 
 type Props = {
-	addImage: (formData: FormData) => Promise<{ message: string }>;
+	addImage: (formData: FormData) => Promise<ServerAction>;
 };
 
 export function ImageFormClient({ addImage }: Props) {

--- a/src/features/news/actions/add-news.ts
+++ b/src/features/news/actions/add-news.ts
@@ -26,6 +26,6 @@ export async function addNews(formData: FormData): Promise<ServerAction> {
 
 		return { success: true, message: "inserted" };
 	} catch (error) {
-		return await wrapServerSideErrorForClient(error);
+		return await wrapServerSideErrorForClient(error, formData);
 	}
 }

--- a/src/features/news/components/client/news-form-client.tsx
+++ b/src/features/news/components/client/news-form-client.tsx
@@ -7,12 +7,13 @@ import { FormInput } from "@/common/components/forms/fields/form-input";
 import { FormInputWithButton } from "@/common/components/forms/fields/form-input-with-button";
 import { FormTextarea } from "@/common/components/forms/fields/form-textarea";
 import { GenericFormWrapper } from "@/common/components/forms/generic-form-wrapper";
+import type { ServerAction } from "@/common/types";
 
 export type NewsFormClientData = { id: string; name: string }[];
 
 type Props = {
 	categories: NewsFormClientData;
-	addNews: (formData: FormData) => Promise<{ message: string }>;
+	addNews: (formData: FormData) => Promise<ServerAction>;
 };
 
 export function NewsFormClient({ categories, addNews }: Props) {

--- a/src/infrastructures/news/repositories/news-query-repository.ts
+++ b/src/infrastructures/news/repositories/news-query-repository.ts
@@ -12,9 +12,10 @@ import type {
 import prisma from "@/prisma";
 
 class NewsQueryRepository implements INewsQueryRepository {
-	findByUrl = async (userId: string, url: string): Promise<{} | null> => {
+	findByUrl = async (url: string, userId: string): Promise<{} | null> => {
 		return await prisma.news.findUnique({
 			where: { url_userId: { url, userId } },
+			select: { url: true },
 		});
 	};
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - フォーム（入力・テキストエリア・ドロップダウン・ボタン付き入力）が送信エラー時に入力値を自動保持・再表示。初期表示のデフォルト値指定にも対応。
- エラーハンドリング
  - エラー応答に送信データを含めて返却。重複時は「duplicated」、その他のDBエラーは汎用メッセージで通知。
- 多言語対応
  - 重複エラーのキーを「duplicated」に統一（日英とも文言は変更なし）。
- UI
  - 画像・ニュース・コンテンツ・書籍フォームで送信結果の扱いを改善し、通知の一貫性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->