### PR TITLE
DRAFT: feat: add unstable cache

### DIFF
--- a/src/application-services/books/add-books.ts
+++ b/src/application-services/books/add-books.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -22,7 +22,8 @@ export async function addBooks(formData: FormData): Promise<ServerAction> {
 
 		await booksCommandRepository.create(validatedBooks);
 
-		revalidatePath("/(dumper)");
+		revalidateTag("books-unexported");
+		revalidateTag("books-count-UNEXPORTED");
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/books/delete-books.ts
+++ b/src/application-services/books/delete-books.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -16,7 +16,8 @@ export async function deleteBooks(id: string): Promise<ServerAction> {
 
 		await booksCommandRepository.deleteById(id, userId, "UNEXPORTED");
 
-		revalidatePath("/(dumper)");
+		revalidateTag("books-unexported");
+		revalidateTag("books-count-UNEXPORTED");
 
 		return { success: true, message: "deleted" };
 	} catch (error) {

--- a/src/application-services/books/get-books.ts
+++ b/src/application-services/books/get-books.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
@@ -5,7 +6,7 @@ import { ImageCardData } from "@/components/common/layouts/cards/image-card";
 import type { Status } from "@/domains/common/entities/common-entity";
 import { booksQueryRepository } from "@/infrastructures/books/repositories/books-query-repository";
 
-export const getExportedBooks = cache(async (): Promise<ImageCardData[]> => {
+const _getExportedBooks = async (): Promise<ImageCardData[]> => {
 	try {
 		const userId = await getSelfId();
 		const books = await booksQueryRepository.findMany(userId, "EXPORTED", {
@@ -22,9 +23,15 @@ export const getExportedBooks = cache(async (): Promise<ImageCardData[]> => {
 	} catch (error) {
 		throw error;
 	}
-});
+};
 
-export const getUnexportedBooks = cache(async (): Promise<ImageCardData[]> => {
+export const getExportedBooks = unstable_cache(
+	_getExportedBooks,
+	["books-exported"],
+	{ tags: ["books-exported"], revalidate: 400 },
+);
+
+const _getUnexportedBooks = async (): Promise<ImageCardData[]> => {
 	try {
 		const userId = await getSelfId();
 		const books = await booksQueryRepository.findMany(userId, "UNEXPORTED", {
@@ -40,21 +47,33 @@ export const getUnexportedBooks = cache(async (): Promise<ImageCardData[]> => {
 	} catch (error) {
 		throw error;
 	}
-});
+};
 
-export const getBooksCount = cache(
-	async (status: Status): Promise<{ count: number; pageSize: number }> => {
-		try {
-			const userId = await getSelfId();
-			return {
-				count: await booksQueryRepository.count(userId, status),
-				pageSize: PAGE_SIZE,
-			};
-		} catch (error) {
-			throw error;
-		}
-	},
+export const getUnexportedBooks = unstable_cache(
+	_getUnexportedBooks,
+	["books-unexported"],
+	{ tags: ["books-unexported"], revalidate: 300 },
 );
+
+const _getBooksCount = async (
+	status: Status,
+): Promise<{ count: number; pageSize: number }> => {
+	try {
+		const userId = await getSelfId();
+		return {
+			count: await booksQueryRepository.count(userId, status),
+			pageSize: PAGE_SIZE,
+		};
+	} catch (error) {
+		throw error;
+	}
+};
+
+export const getBooksCount = (status: Status) =>
+	unstable_cache(() => _getBooksCount(status), [`books-count-${status}`], {
+		tags: [`books-count-${status}`],
+		revalidate: 60,
+	})();
 
 export const getBookByISBN = cache(async (isbn: string) => {
 	try {

--- a/src/application-services/contents/add-contents.ts
+++ b/src/application-services/contents/add-contents.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -28,7 +28,8 @@ export async function addContents(formData: FormData): Promise<ServerAction> {
 
 		await contentsCommandRepository.create(validatedContents);
 
-		revalidatePath("/(dumper)");
+		revalidateTag("contents-unexported");
+		revalidateTag("contents-count-UNEXPORTED");
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/contents/delete-contents.ts
+++ b/src/application-services/contents/delete-contents.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -16,7 +16,8 @@ export async function deleteContents(id: string): Promise<ServerAction> {
 
 		await contentsCommandRepository.deleteById(id, userId, "UNEXPORTED");
 
-		revalidatePath("/(dumper)");
+		revalidateTag("contents-unexported");
+		revalidateTag("contents-count-UNEXPORTED");
 
 		return { success: true, message: "deleted" };
 	} catch (error) {

--- a/src/application-services/images/add-image.ts
+++ b/src/application-services/images/add-image.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -34,7 +34,8 @@ export async function addImage(formData: FormData): Promise<ServerAction> {
 		);
 		await imagesCommandRepository.create(validatedImages);
 
-		revalidatePath("/(dumper)");
+		revalidateTag("images-unexported");
+		revalidateTag("images-count-UNEXPORTED");
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/images/delete-images.ts
+++ b/src/application-services/images/delete-images.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -16,7 +16,8 @@ export async function deleteImages(id: string): Promise<ServerAction> {
 
 		await imagesCommandRepository.deleteById(id, userId, "UNEXPORTED");
 
-		revalidatePath("/(dumper)");
+		revalidateTag("images-unexported");
+		revalidateTag("images-count-UNEXPORTED");
 
 		return { success: true, message: "deleted" };
 	} catch (error) {

--- a/src/application-services/news/add-news.ts
+++ b/src/application-services/news/add-news.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -22,7 +22,9 @@ export async function addNews(formData: FormData): Promise<ServerAction> {
 
 		await newsCommandRepository.create(validatedNews);
 
-		revalidatePath("/(dumper)");
+		revalidateTag("news-unexported");
+		revalidateTag("news-count-UNEXPORTED");
+		revalidateTag("categories");
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/news/delete-news.ts
+++ b/src/application-services/news/delete-news.ts
@@ -1,6 +1,6 @@
 "use server";
 import "server-only";
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { forbidden } from "next/navigation";
 import { getSelfId, hasDumperPostPermission } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
@@ -16,7 +16,8 @@ export async function deleteNews(id: string): Promise<ServerAction> {
 
 		await newsCommandRepository.deleteById(id, userId, "UNEXPORTED");
 
-		revalidatePath("/(dumper)");
+		revalidateTag("news-unexported");
+		revalidateTag("news-count-UNEXPORTED");
 
 		return { success: true, message: "deleted" };
 	} catch (error) {

--- a/src/application-services/news/get-news.ts
+++ b/src/application-services/news/get-news.ts
@@ -1,4 +1,4 @@
-import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
 import type { LinkCardData } from "@/components/common/layouts/cards/link-card";
@@ -10,74 +10,88 @@ import {
 } from "@/infrastructures/news/repositories/news-query-repository";
 import { serverLogger } from "@/infrastructures/observability/server";
 
-export const getExportedNews = cache(
-	async (page: number): Promise<LinkCardData[]> => {
-		try {
-			const userId = await getSelfId();
-			const news = await newsQueryRepository.findMany(userId, "EXPORTED", {
-				skip: (page - 1) * PAGE_SIZE,
-				take: PAGE_SIZE,
-				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: ["news"] },
-			});
+const _getExportedNews = async (page: number): Promise<LinkCardData[]> => {
+	try {
+		const userId = await getSelfId();
+		const news = await newsQueryRepository.findMany(userId, "EXPORTED", {
+			skip: (page - 1) * PAGE_SIZE,
+			take: PAGE_SIZE,
+			orderBy: { createdAt: "desc" },
+			cacheStrategy: { ttl: 400, swr: 40, tags: ["news"] },
+		});
 
-			return news.map((d) => ({
-				id: d.id,
-				primaryBadgeText: d.category.name,
-				secondaryBadgeText: new URL(d.url).hostname,
-				key: d.id,
-				title: d.title,
-				description:
-					`${d.quote} \n ${d.ogTitle} \n ${d.ogDescription}`.slice(0, 200) +
-					"...",
-				href: d.url,
-			}));
-		} catch (error) {
-			throw error;
-		}
-	},
+		return news.map((d) => ({
+			id: d.id,
+			primaryBadgeText: d.category.name,
+			secondaryBadgeText: new URL(d.url).hostname,
+			key: d.id,
+			title: d.title,
+			description:
+				`${d.quote} \n ${d.ogTitle} \n ${d.ogDescription}`.slice(0, 200) +
+				"...",
+			href: d.url,
+		}));
+	} catch (error) {
+		throw error;
+	}
+};
+
+export const getExportedNews = unstable_cache(
+	_getExportedNews,
+	["news-exported"],
+	{ tags: ["news-exported"], revalidate: 400 },
 );
 
-export const getUnexportedNews = cache(
-	async (page: number): Promise<LinkCardData[]> => {
-		try {
-			const userId = await getSelfId();
-			const news = await newsQueryRepository.findMany(userId, "UNEXPORTED", {
-				skip: (page - 1) * PAGE_SIZE,
-				take: PAGE_SIZE,
-				orderBy: { createdAt: "desc" },
-			});
+const _getUnexportedNews = async (page: number): Promise<LinkCardData[]> => {
+	try {
+		const userId = await getSelfId();
+		const news = await newsQueryRepository.findMany(userId, "UNEXPORTED", {
+			skip: (page - 1) * PAGE_SIZE,
+			take: PAGE_SIZE,
+			orderBy: { createdAt: "desc" },
+		});
 
-			return news.map((d) => ({
-				id: d.id,
-				primaryBadgeText: d.category.name,
-				secondaryBadgeText: new URL(d.url).hostname,
-				key: d.id,
-				title: d.title,
-				description: d.quote ?? undefined,
-				href: d.url,
-			}));
-		} catch (error) {
-			throw error;
-		}
-	},
+		return news.map((d) => ({
+			id: d.id,
+			primaryBadgeText: d.category.name,
+			secondaryBadgeText: new URL(d.url).hostname,
+			key: d.id,
+			title: d.title,
+			description: d.quote ?? undefined,
+			href: d.url,
+		}));
+	} catch (error) {
+		throw error;
+	}
+};
+
+export const getUnexportedNews = unstable_cache(
+	_getUnexportedNews,
+	["news-unexported"],
+	{ tags: ["news-unexported"], revalidate: 300 },
 );
 
-export const getNewsCount = cache(
-	async (status: Status): Promise<{ count: number; pageSize: number }> => {
-		try {
-			const userId = await getSelfId();
-			return {
-				count: await newsQueryRepository.count(userId, status),
-				pageSize: PAGE_SIZE,
-			};
-		} catch (error) {
-			throw error;
-		}
-	},
-);
+const _getNewsCount = async (
+	status: Status,
+): Promise<{ count: number; pageSize: number }> => {
+	try {
+		const userId = await getSelfId();
+		return {
+			count: await newsQueryRepository.count(userId, status),
+			pageSize: PAGE_SIZE,
+		};
+	} catch (error) {
+		throw error;
+	}
+};
 
-export const getCategories = cache(async (): Promise<NewsFormClientData> => {
+export const getNewsCount = (status: Status) =>
+	unstable_cache(() => _getNewsCount(status), [`news-count-${status}`], {
+		tags: [`news-count-${status}`],
+		revalidate: 60,
+	})();
+
+const _getCategories = async (): Promise<NewsFormClientData> => {
 	try {
 		const userId = await getSelfId();
 		const response = await categoryQueryRepository.findMany(userId, {
@@ -93,4 +107,10 @@ export const getCategories = cache(async (): Promise<NewsFormClientData> => {
 		// not critical for viewer nor dumper
 		return [];
 	}
-});
+};
+
+export const getCategories = () =>
+	unstable_cache(() => _getCategories(), ["categories"], {
+		tags: ["categories"],
+		revalidate: 60,
+	})();


### PR DESCRIPTION
Fixes #1417 

- [ ] use cache に変更
- [ ] 下記エラー

```
Route /[locale] used "headers" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "headers" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - タブコンテンツの事前読み込みを追加し、非表示時もバックグラウンドで読み込み可能に
  - ルートタブとフッターでのルート/タブのプリフェッチにより遷移を高速化
- リファクタ
  - コンポーネントのメモ化と遷移最適化でUIの応答性を向上
  - URLクエリと内部状態の同期を強化し、無効なパラメータを自動補正
  - データ取得のキャッシュ戦略を刷新し、タグベースの再検証で最新情報の反映を高速化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->