### PR TITLE
Fix/cache tag on prisma

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"uuid": "11.1.0",
 		"vaul": "1.1.2",
 		"yet-another-react-lightbox": "3.25.0",
-		"zod": "3.25.76"
+		"zod": "4.0.17"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@15.4.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.101.1(@swc/core@1.13.3)(esbuild@0.25.9))
       '@t3-oss/env-nextjs':
         specifier: 0.13.8
-        version: 0.13.8(typescript@5.9.2)(zod@3.25.76)
+        version: 0.13.8(typescript@5.9.2)(zod@4.0.17)
       '@tailwindcss/typography':
         specifier: 0.5.16
         version: 0.5.16(tailwindcss@4.1.11)
@@ -102,8 +102,8 @@ importers:
         specifier: 3.25.0
         version: 3.25.0(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.0.17
+        version: 4.0.17
     devDependencies:
       '@biomejs/biome':
         specifier: 2.1.4
@@ -7864,6 +7864,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.0.17:
+    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -10541,17 +10544,17 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@t3-oss/env-core@0.13.8(typescript@5.9.2)(zod@3.25.76)':
+  '@t3-oss/env-core@0.13.8(typescript@5.9.2)(zod@4.0.17)':
     optionalDependencies:
       typescript: 5.9.2
-      zod: 3.25.76
+      zod: 4.0.17
 
-  '@t3-oss/env-nextjs@0.13.8(typescript@5.9.2)(zod@3.25.76)':
+  '@t3-oss/env-nextjs@0.13.8(typescript@5.9.2)(zod@4.0.17)':
     dependencies:
-      '@t3-oss/env-core': 0.13.8(typescript@5.9.2)(zod@3.25.76)
+      '@t3-oss/env-core': 0.13.8(typescript@5.9.2)(zod@4.0.17)
     optionalDependencies:
       typescript: 5.9.2
-      zod: 3.25.76
+      zod: 4.0.17
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -16675,5 +16678,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.0.17: {}
 
   zwitch@2.0.4: {}

--- a/src/application-services/books/add-books.test.ts
+++ b/src/application-services/books/add-books.test.ts
@@ -55,7 +55,7 @@ describe("addBooks", () => {
 		vi.mocked(getSelfId).mockResolvedValue("user-123");
 
 		mockPrepareNewBook.mockResolvedValue({
-			id: "01234567-89ab-cdef-0123-456789abcdef",
+			id: "01234567-89ab-4def-9123-456789abcdef",
 			isbn: "978-4-06-519981-0",
 			title: "Test Book",
 			userId: "user-123",

--- a/src/application-services/books/get-books.test.ts
+++ b/src/application-services/books/get-books.test.ts
@@ -48,7 +48,7 @@ describe("get-books", () => {
 				"EXPORTED",
 				expect.objectContaining({
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["books"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-books"] },
 				}),
 			);
 

--- a/src/application-services/books/get-books.ts
+++ b/src/application-services/books/get-books.ts
@@ -10,7 +10,7 @@ export const getExportedBooks = cache(async (): Promise<ImageCardData[]> => {
 		const userId = await getSelfId();
 		const books = await booksQueryRepository.findMany(userId, "EXPORTED", {
 			orderBy: { createdAt: "desc" },
-			cacheStrategy: { ttl: 400, swr: 40, tags: ["books"] },
+			cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-books`] },
 		});
 
 		return books.map((d) => ({

--- a/src/application-services/contents/add-contents.test.ts
+++ b/src/application-services/contents/add-contents.test.ts
@@ -56,7 +56,7 @@ describe("addContents", () => {
 			markdown: "sample markdown",
 			userId: "user-123",
 			status: "UNEXPORTED",
-			id: "01234567-89ab-cdef-0123-456789abcdef",
+			id: "01234567-89ab-4def-9123-456789abcdef",
 		});
 		vi.mocked(contentsCommandRepository.create).mockResolvedValue();
 

--- a/src/application-services/contents/get-contents.test.ts
+++ b/src/application-services/contents/get-contents.test.ts
@@ -53,7 +53,7 @@ describe("get-contents", () => {
 				"EXPORTED",
 				expect.objectContaining({
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["contents"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-contents"] },
 				}),
 			);
 

--- a/src/application-services/contents/get-contents.ts
+++ b/src/application-services/contents/get-contents.ts
@@ -13,7 +13,7 @@ export const getExportedContents = cache(async (): Promise<LinkCardData[]> => {
 			"EXPORTED",
 			{
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: ["contents"] },
+				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-contents`] },
 			},
 		);
 

--- a/src/application-services/images/get-images.test.ts
+++ b/src/application-services/images/get-images.test.ts
@@ -55,7 +55,7 @@ describe("get-images", () => {
 					skip: 0,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["images"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-images"] },
 				},
 			);
 
@@ -89,7 +89,7 @@ describe("get-images", () => {
 					skip: 48,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["images"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-images"] },
 				},
 			);
 		});

--- a/src/application-services/images/get-images.ts
+++ b/src/application-services/images/get-images.ts
@@ -16,7 +16,7 @@ export const getExportedImages = cache(
 				skip: (page - 1) * PAGE_SIZE,
 				take: PAGE_SIZE,
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: ["images"] },
+				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-images`] },
 			});
 			return data.map((d) => {
 				return {

--- a/src/application-services/news/add-news.test.ts
+++ b/src/application-services/news/add-news.test.ts
@@ -58,14 +58,14 @@ describe("addNews", () => {
 			category: {
 				name: "tech",
 				userId: "user-123",
-				id: "01234567-89ab-cdef-0123-456789abcdef",
+				id: "01234567-89ab-4def-9123-456789abcdef",
 			},
 			title: "Example Content",
 			quote: "This is an example news quote.",
 			url: "https://example.com",
 			userId: "user-123",
 			status: "UNEXPORTED",
-			id: "01234567-89ab-cdef-0123-456789abcdef",
+			id: "01234567-89ab-4def-9123-456789abcdef",
 		});
 		vi.mocked(newsCommandRepository.create).mockResolvedValue();
 

--- a/src/application-services/news/get-news.test.ts
+++ b/src/application-services/news/get-news.test.ts
@@ -229,7 +229,7 @@ describe("get-news", () => {
 		test("should fetch categories correctly", async () => {
 			const mockCategories = [
 				{
-					id: "01234567-89ab-cdef-0123-456789abcdef",
+					id: "01234567-89ab-4def-9123-456789abcdef",
 					name: "Science",
 				},
 				{
@@ -253,7 +253,7 @@ describe("get-news", () => {
 
 			expect(result).toEqual([
 				{
-					id: "01234567-89ab-cdef-0123-456789abcdef",
+					id: "01234567-89ab-4def-9123-456789abcdef",
 					name: "Science",
 				},
 				{

--- a/src/application-services/news/get-news.test.ts
+++ b/src/application-services/news/get-news.test.ts
@@ -61,7 +61,7 @@ describe("get-news", () => {
 					skip: 0,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["news"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-news"] },
 				},
 			);
 
@@ -99,7 +99,7 @@ describe("get-news", () => {
 					skip: 48,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["news"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-news"] },
 				},
 			);
 		});

--- a/src/application-services/news/get-news.ts
+++ b/src/application-services/news/get-news.ts
@@ -18,7 +18,7 @@ export const getExportedNews = cache(
 				skip: (page - 1) * PAGE_SIZE,
 				take: PAGE_SIZE,
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: ["news"] },
+				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-news`] },
 			});
 
 			return news.map((d) => ({

--- a/src/components/books/server/viewer-body.stories.tsx
+++ b/src/components/books/server/viewer-body.stories.tsx
@@ -42,7 +42,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const mockBookData: BookData = {
-	id: "01234567-89ab-cdef-0123-456789abcdef",
+	id: "01234567-89ab-4def-9123-456789abcdef",
 	ISBN: "978-0123456789",
 	title: "TypeScript Handbook",
 	markdown:
@@ -125,7 +125,7 @@ export const MinimalData: Story = {
 	args: {
 		slug: "978-0123456789",
 		getBookByISBN: async () => ({
-			id: "01234567-89ab-cdef-0123-456789abcdef",
+			id: "01234567-89ab-4def-9123-456789abcdef",
 			ISBN: "978-0123456789",
 			title: "Minimal Book",
 			markdown: "# Minimal Book\n\nJust some basic content.",

--- a/src/components/common/layouts/nav/util-buttons.stories.tsx
+++ b/src/components/common/layouts/nav/util-buttons.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { UtilButtons } from "./util-buttons";
 
 type UtilButtonsWrapperProps = {
@@ -49,8 +50,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
-		handleReload: () => console.log("Reload clicked"),
-		onSignOutSubmit: async () => console.log("Sign out clicked"),
+		handleReload: fn(),
+		onSignOutSubmit: fn(),
 	},
 	parameters: {
 		nextjs: {
@@ -63,8 +64,8 @@ export const Default: Story = {
 
 export const DarkTheme: Story = {
 	args: {
-		handleReload: () => console.log("Reload clicked"),
-		onSignOutSubmit: async () => console.log("Sign out clicked"),
+		handleReload: fn(),
+		onSignOutSubmit: fn(),
 		theme: "dark",
 	},
 	parameters: {
@@ -81,8 +82,8 @@ export const DarkTheme: Story = {
 
 export const JapaneseLocale: Story = {
 	args: {
-		handleReload: () => console.log("Reload clicked"),
-		onSignOutSubmit: async () => console.log("Sign out clicked"),
+		handleReload: fn(),
+		onSignOutSubmit: fn(),
 		locale: "ja",
 	},
 	parameters: {
@@ -96,8 +97,8 @@ export const JapaneseLocale: Story = {
 
 export const OnAuthPage: Story = {
 	args: {
-		handleReload: () => console.log("Reload clicked"),
-		onSignOutSubmit: async () => console.log("Sign out clicked"),
+		handleReload: fn(),
+		onSignOutSubmit: fn(),
 		pathname: "/auth",
 	},
 	parameters: {
@@ -111,8 +112,8 @@ export const OnAuthPage: Story = {
 
 export const DarkThemeJapanese: Story = {
 	args: {
-		handleReload: () => console.log("Reload clicked"),
-		onSignOutSubmit: async () => console.log("Sign out clicked"),
+		handleReload: fn(),
+		onSignOutSubmit: fn(),
 		theme: "dark",
 		locale: "ja",
 	},

--- a/src/domains/books/entities/books-entity.test.ts
+++ b/src/domains/books/entities/books-entity.test.ts
@@ -137,7 +137,7 @@ describe("booksEntity", () => {
 			const data = {
 				ISBN: "978-0123456789",
 				title: "Sample Book",
-				id: "01234567-89ab-cdef-0123-456789abcdef",
+				id: "01234567-89ab-4def-9123-456789abcdef",
 				googleTitle: "Google Title",
 				googleAuthors: ["Author"],
 				markdown: "# Notes",

--- a/src/domains/contents/entities/contents-entity.test.ts
+++ b/src/domains/contents/entities/contents-entity.test.ts
@@ -25,7 +25,7 @@ describe("contentsEntity", () => {
 		const result = contentsFormSchema.safeParse(invalidData);
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(result.error.errors[0].message).toBe("required");
+			expect(result.error.issues[0].message).toBe("required");
 		}
 	});
 
@@ -40,7 +40,7 @@ describe("contentsEntity", () => {
 		const result = contentsFormSchema.safeParse(invalidData);
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(result.error.errors[0].message).toBe("tooLong");
+			expect(result.error.issues[0].message).toBe("tooLong");
 		}
 	});
 
@@ -55,7 +55,7 @@ describe("contentsEntity", () => {
 		const result = contentsFormSchema.safeParse(invalidData);
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(result.error.errors[0].message).toBe("required");
+			expect(result.error.issues[0].message).toBe("required");
 		}
 	});
 
@@ -70,7 +70,7 @@ describe("contentsEntity", () => {
 		const result = contentsFormSchema.safeParse(invalidData);
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(result.error.errors[0].message).toBe("required");
+			expect(result.error.issues[0].message).toBe("required");
 		}
 	});
 });

--- a/src/domains/contents/services/contents-domain-service.test.ts
+++ b/src/domains/contents/services/contents-domain-service.test.ts
@@ -5,7 +5,7 @@ import { ContentsDomainService } from "./contents-domain-service";
 
 // Mock at the module level before any imports
 vi.mock("uuid", () => ({
-	v7: () => "01234567-89ab-cdef-0123-456789abcdef",
+	v7: () => "01234567-89ab-4def-9123-456789abcdef",
 }));
 
 describe("ContentsDomainService", () => {

--- a/src/domains/images/services/images-domain-service.test.ts
+++ b/src/domains/images/services/images-domain-service.test.ts
@@ -8,7 +8,7 @@ import type { IImagesQueryRepository } from "../types";
 import { ImagesDomainService, sanitizeFileName } from "./images-domain-service";
 
 vi.mock("uuid", () => ({
-	v7: () => "01234567-89ab-cdef-0123-456789abcdef",
+	v7: () => "01234567-89ab-4def-9123-456789abcdef",
 }));
 
 describe("sanitizeFileName", () => {
@@ -185,7 +185,7 @@ describe("ImagesDomainService", () => {
 			// Mock findByPath to return an existing image
 			vi.mocked(imagesQueryRepository.findByPath).mockResolvedValue({
 				id: "existing-id",
-				path: "01234567-89ab-cdef-0123-456789abcdef-test.jpg",
+				path: "01234567-89ab-4def-9123-456789abcdef-test.jpg",
 			});
 
 			const formData = new FormData();
@@ -197,7 +197,7 @@ describe("ImagesDomainService", () => {
 			).rejects.toThrow(DuplicateError);
 
 			expect(imagesQueryRepository.findByPath).toHaveBeenCalledWith(
-				"01234567-89ab-cdef-0123-456789abcdef-test.jpg",
+				"01234567-89ab-4def-9123-456789abcdef-test.jpg",
 				"user-123",
 			);
 		});

--- a/src/domains/news/entities/news-entity.test.ts
+++ b/src/domains/news/entities/news-entity.test.ts
@@ -180,7 +180,7 @@ describe("newsEntity", () => {
 		test("categoryQueryData should omit userId", () => {
 			const data = {
 				name: "tech",
-				id: "01234567-89ab-cdef-0123-456789abcdef",
+				id: "01234567-89ab-4def-9123-456789abcdef",
 			};
 
 			const result = categoryQueryData.safeParse(data);
@@ -191,12 +191,12 @@ describe("newsEntity", () => {
 			const data = {
 				category: {
 					name: "tech",
-					id: "01234567-89ab-cdef-0123-456789abcdef",
+					id: "01234567-89ab-4def-9123-456789abcdef",
 				},
 				title: "Sample News",
 				quote: "Quote",
 				url: "https://example.com",
-				id: "01234567-89ab-cdef-0123-456789abcdef",
+				id: "01234567-89ab-4def-9123-456789abcdef",
 				ogTitle: "OG Title",
 				ogDescription: "OG Description",
 			};

--- a/src/infrastructures/news/repositories/news-command-repository.test.ts
+++ b/src/infrastructures/news/repositories/news-command-repository.test.ts
@@ -33,7 +33,7 @@ describe("NewsCommandRepository", () => {
 				url: "https://example.com/news/1",
 				quote: "This is a test quote",
 				userId: "user123",
-				id: "01234567-89ab-cdef-0123-456789abcdef",
+				id: "01234567-89ab-4def-9123-456789abcdef",
 				status: "UNEXPORTED",
 				category: {
 					name: "tech",
@@ -113,7 +113,7 @@ describe("NewsCommandRepository", () => {
 					url: "https://example.com/news/1",
 					quote: "This is a test quote",
 					userId: "user123",
-					id: "01234567-89ab-cdef-0123-456789abcdef",
+					id: "01234567-89ab-4def-9123-456789abcdef",
 					status: "UNEXPORTED",
 					category: {
 						name: "tech",


### PR DESCRIPTION
Fixes #1559 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 書籍・コンテンツ・画像・ニュースのエクスポート一覧でキャッシュをユーザー単位に変更し、結果の正確性とパフォーマンスの安定性を向上。
- テスト
  - モックID・期待値を更新。Storybook の操作ハンドラを fn() に統一。
- チョア
  - 依存関係 zod を v4 に更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->