### PR TITLE
fix: error on prisma cache

### DIFF
--- a/src/application-services/books/get-books.test.ts
+++ b/src/application-services/books/get-books.test.ts
@@ -48,7 +48,7 @@ describe("get-books", () => {
 				"EXPORTED",
 				expect.objectContaining({
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-books"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-books"] },
 				}),
 			);
 

--- a/src/application-services/books/get-books.ts
+++ b/src/application-services/books/get-books.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
+import { sanitizeCacheTag } from "@/common/utils/cache-utils";
 import { ImageCardData } from "@/components/common/layouts/cards/image-card";
 import type { Status } from "@/domains/common/entities/common-entity";
 import { booksQueryRepository } from "@/infrastructures/books/repositories/books-query-repository";
@@ -10,7 +11,11 @@ export const getExportedBooks = cache(async (): Promise<ImageCardData[]> => {
 		const userId = await getSelfId();
 		const books = await booksQueryRepository.findMany(userId, "EXPORTED", {
 			orderBy: { createdAt: "desc" },
-			cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-books`] },
+			cacheStrategy: {
+				ttl: 400,
+				swr: 40,
+				tags: [`${sanitizeCacheTag(userId)}-books`],
+			},
 		});
 
 		return books.map((d) => ({

--- a/src/application-services/contents/get-contents.test.ts
+++ b/src/application-services/contents/get-contents.test.ts
@@ -53,7 +53,7 @@ describe("get-contents", () => {
 				"EXPORTED",
 				expect.objectContaining({
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-contents"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-contents"] },
 				}),
 			);
 

--- a/src/application-services/contents/get-contents.ts
+++ b/src/application-services/contents/get-contents.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
+import { sanitizeCacheTag } from "@/common/utils/cache-utils";
 import { LinkCardData } from "@/components/common/layouts/cards/link-card";
 import type { Status } from "@/domains/common/entities/common-entity";
 import { contentsQueryRepository } from "@/infrastructures/contents/repositories/contents-query-repository";
@@ -13,7 +14,11 @@ export const getExportedContents = cache(async (): Promise<LinkCardData[]> => {
 			"EXPORTED",
 			{
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-contents`] },
+				cacheStrategy: {
+					ttl: 400,
+					swr: 40,
+					tags: [`${sanitizeCacheTag(userId)}-contents`],
+				},
 			},
 		);
 

--- a/src/application-services/images/get-images.test.ts
+++ b/src/application-services/images/get-images.test.ts
@@ -55,7 +55,7 @@ describe("get-images", () => {
 					skip: 0,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-images"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-images"] },
 				},
 			);
 
@@ -89,7 +89,7 @@ describe("get-images", () => {
 					skip: 48,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-images"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-images"] },
 				},
 			);
 		});

--- a/src/application-services/images/get-images.ts
+++ b/src/application-services/images/get-images.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
+import { sanitizeCacheTag } from "@/common/utils/cache-utils";
 import { ImageData } from "@/components/common/display/image/image-stack";
 import type { Status } from "@/domains/common/entities/common-entity";
 import { imagesQueryRepository } from "@/infrastructures/images/repositories/images-query-repository";
@@ -16,7 +17,11 @@ export const getExportedImages = cache(
 				skip: (page - 1) * PAGE_SIZE,
 				take: PAGE_SIZE,
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-images`] },
+				cacheStrategy: {
+					ttl: 400,
+					swr: 40,
+					tags: [`${sanitizeCacheTag(userId)}-images`],
+				},
 			});
 			return data.map((d) => {
 				return {

--- a/src/application-services/news/get-news.test.ts
+++ b/src/application-services/news/get-news.test.ts
@@ -61,7 +61,7 @@ describe("get-news", () => {
 					skip: 0,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-news"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-news"] },
 				},
 			);
 
@@ -99,7 +99,7 @@ describe("get-news", () => {
 					skip: 48,
 					take: 24,
 					orderBy: { createdAt: "desc" },
-					cacheStrategy: { ttl: 400, swr: 40, tags: ["test-user-id-news"] },
+					cacheStrategy: { ttl: 400, swr: 40, tags: ["testuserid-news"] },
 				},
 			);
 		});

--- a/src/application-services/news/get-news.ts
+++ b/src/application-services/news/get-news.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { getSelfId } from "@/common/auth/session";
 import { PAGE_SIZE } from "@/common/constants";
+import { sanitizeCacheTag } from "@/common/utils/cache-utils";
 import type { LinkCardData } from "@/components/common/layouts/cards/link-card";
 import type { NewsFormClientData } from "@/components/news/client/news-form-client";
 import type { Status } from "@/domains/common/entities/common-entity";
@@ -18,7 +19,11 @@ export const getExportedNews = cache(
 				skip: (page - 1) * PAGE_SIZE,
 				take: PAGE_SIZE,
 				orderBy: { createdAt: "desc" },
-				cacheStrategy: { ttl: 400, swr: 40, tags: [`${userId}-news`] },
+				cacheStrategy: {
+					ttl: 400,
+					swr: 40,
+					tags: [`${sanitizeCacheTag(userId)}-news`],
+				},
 			});
 
 			return news.map((d) => ({

--- a/src/common/utils/cache-utils.test.ts
+++ b/src/common/utils/cache-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { sanitizeCacheTag } from "./cache-utils";
+
+describe("sanitizeCacheTag", () => {
+	test("should keep only alphabets and underscores", () => {
+		const userId = "abc123_DEF456";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("abc_DEF");
+	});
+
+	test("should remove Auth0-style user IDs with pipes and colons", () => {
+		const userId = "auth0|6123456789abcdef";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("authabcdef");
+	});
+
+	test("should remove all special characters except underscores", () => {
+		const userId = "user@domain.com|123:456-789_test";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("userdomaincom_test");
+	});
+
+	test("should handle empty string", () => {
+		const userId = "";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("");
+	});
+
+	test("should return empty string if only special characters", () => {
+		const userId = "123@#$%^&*(){}[]|\\:;\"'<>,.?/";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("");
+	});
+
+	test("should preserve underscores", () => {
+		const userId = "user_123_test_456";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("user__test_");
+	});
+
+	test("should handle mixed case letters", () => {
+		const userId = "AbC123dEf456_XyZ";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("AbCdEf_XyZ");
+	});
+
+	test("should handle Unicode characters", () => {
+		const userId = "user日本語123_test";
+		const result = sanitizeCacheTag(userId);
+		expect(result).toBe("user_test");
+	});
+});

--- a/src/common/utils/cache-utils.ts
+++ b/src/common/utils/cache-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Sanitizes a user ID for use in cache tags.
+ * Only allows alphabetic characters (a-z, A-Z) and underscores.
+ * Removes all other characters to ensure cache tag compatibility.
+ *
+ * @param userId - The user ID to sanitize
+ * @returns The sanitized user ID containing only alphabets and underscores
+ */
+export function sanitizeCacheTag(userId: string): string {
+	return userId.replaceAll(/[^a-zA-Z_]/g, "");
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - エクスポート済みの本・コンテンツ・画像・ニュース取得時のキャッシュタグをサニタイズして一貫化。記号や数字を除去し、不正なタグによるキャッシュミスや想定外の無効化を防止し安定性向上。

- パフォーマンス
  - キャッシュキーの一貫性向上によりキャッシュヒット率を改善。

- テスト
  - サニタイズ処理の単体テストを追加。
  - 既存テストの期待値を新しいタグ形式に合わせて更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->