### PR TITLE
refactor: add update-db command from s-contents

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -25,5 +25,31 @@
 	"ignoreBinaries": [
 		"config-inspector",
 		"dot" // for depencency-cruiser
-	]
+	],
+	"next": {
+		"config": [
+			"next.config.{js,ts,cjs,mjs}"
+		],
+		"entry": [
+			"{instrumentation,instrumentation-client,middleware}.{js,ts}",
+			"app/global-error.{js,jsx,ts,tsx}",
+			"app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}",
+			"app/**/route.{js,jsx,ts,tsx}",
+			"app/{manifest,sitemap,robots}.{js,ts}",
+			"app/**/{icon,apple-icon}.{js,jsx,ts,tsx}",
+			"app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}",
+			"mdx-components.{js,jsx,ts,tsx}",
+			"pages/**/*.{js,jsx,ts,tsx}",
+			"src/{instrumentation,instrumentation-client,middleware}.{js,ts}",
+			"src/app/global-error.{js,jsx,ts,tsx}",
+			"src/app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}",
+			"src/app/**/route.{js,jsx,ts,tsx}",
+			"src/app/{manifest,sitemap,robots}.{js,ts}",
+			"src/app/**/{icon,apple-icon}.{js,jsx,ts,tsx}",
+			"src/app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}",
+			"src/mdx-components.{js,jsx,ts,tsx}",
+			"src/pages/**/*.{js,jsx,ts,tsx}",
+			"scripts/**/*.ts"
+		]
+	}
 }

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -27,9 +27,7 @@
 		"dot" // for depencency-cruiser
 	],
 	"next": {
-		"config": [
-			"next.config.{js,ts,cjs,mjs}"
-		],
+		"config": ["next.config.{js,ts,cjs,mjs}"],
 		"entry": [
 			"{instrumentation,instrumentation-client,middleware}.{js,ts}",
 			"app/global-error.{js,jsx,ts,tsx}",

--- a/scripts/update-and-create.ts
+++ b/scripts/update-and-create.ts
@@ -1,0 +1,400 @@
+import fs from "node:fs";
+import { join } from "node:path";
+import * as Minio from "minio";
+import sharp from "sharp";
+import { v7 as randomUUIDv7 } from "uuid";
+import {
+	makeArticleTitle,
+	makeCategoryName,
+	makeOgDescription,
+	makeOgImageUrl,
+	makeOgTitle,
+	makeQuote,
+	makeUrl,
+} from "@/domains/articles/entities/article-entity";
+import { ArticlesDomainService } from "@/domains/articles/services/articles-domain-service";
+import { makeUserId } from "@/domains/common/entities/common-entity";
+import {
+	makeMarkdown,
+	makeNoteTitle,
+} from "@/domains/notes/entities/note-entity";
+import { NotesDomainService } from "@/domains/notes/services/notes-domain-service";
+import { articlesCommandRepository } from "@/infrastructures/articles/repositories/articles-command-repository";
+import { articlesQueryRepository } from "@/infrastructures/articles/repositories/articles-query-repository";
+import { notesCommandRepository } from "@/infrastructures/notes/repositories/notes-command-repository";
+import { notesQueryRepository } from "@/infrastructures/notes/repositories/notes-query-repository";
+import { PrismaClient } from "../src/generated";
+
+type Book = {
+	ISBN: string;
+	title: string;
+	googleTitle: string;
+	googleSubtitle: string;
+	googleAuthors: string[];
+	googleDescription: string;
+	googleImgSrc: string;
+	googleHref: string;
+	tags: string[];
+	rating: number;
+};
+
+async function fetchBookData(): Promise<Book[]> {
+	const url =
+		"https://raw.githubusercontent.com/s-hirano-ist/s-public/main/src/data/book/data.gen.json";
+	try {
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch book data: ${response.statusText}`);
+		}
+		const data = await response.json();
+		return data as Book[];
+	} catch (error) {
+		console.error("Error fetching book data:", error);
+		throw error;
+	}
+}
+
+// NOTE: sync with s-private/src/constants
+export const ORIGINAL_IMAGE_PATH = "images/original";
+export const THUMBNAIL_IMAGE_PATH = "images/thumbnail";
+const THUMBNAIL_WIDTH = 192;
+const THUMBNAIL_HEIGHT = 192;
+
+const prisma = new PrismaClient();
+
+const minioClient = new Minio.Client({
+	endPoint: process.env.MINIO_HOST ?? "",
+	port: Number(process.env.MINIO_PORT) ?? 9000,
+	useSSL: true,
+	accessKey: process.env.MINIO_ACCESS_KEY,
+	secretKey: process.env.MINIO_SECRET_KEY,
+});
+
+const MINIO_BUCKET_NAME = process.env.MINIO_BUCKET_NAME;
+if (!MINIO_BUCKET_NAME) throw new Error("Env not set.");
+
+function getAllSlugs(contentsDirectory: string) {
+	return fs
+		.readdirSync(contentsDirectory)
+		.filter((slug) => slug !== ".DS_Store");
+}
+
+function getMarkdownBySlug(slug: string, contentsDirectory: string) {
+	const realSlug = slug.replace(/\.md$/, "");
+	const fullPath = join(contentsDirectory, `${realSlug}.md`);
+	const fileContents = fs.readFileSync(fullPath, "utf8");
+	return fileContents;
+}
+
+function getJsonBySlug(slug: string, contentsDirectory: string) {
+	const fullPath = join(contentsDirectory, slug);
+	const fileContents = fs.readFileSync(fullPath, "utf8");
+	return JSON.parse(fileContents);
+}
+
+async function optimizeImage(buffer: Buffer) {
+	return await sharp(buffer)
+		.resize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
+		.toBuffer();
+}
+
+async function addBooks() {
+	const USER_ID = process.env.USER_ID;
+	if (!USER_ID) throw new Error("Env not set.");
+
+	const path = "book";
+	const contentsDirectory = join(process.cwd(), "markdown", path);
+
+	const bookData = await fetchBookData();
+
+	const slugs = getAllSlugs(contentsDirectory);
+	await Promise.all(
+		bookData.map(async (book) => {
+			const slug = slugs.find((slug) => {
+				const isbn = slug.replace(/\.md$/, "");
+				return isbn === book.ISBN;
+			});
+			if (!slug)
+				throw new Error(
+					`Book data not found for title: ${book.title} ${book.ISBN}`,
+				);
+
+			const markdown = getMarkdownBySlug(slug, contentsDirectory);
+
+			const existingBook = await prisma.book.findUnique({
+				where: { ISBN_userId: { ISBN: book.ISBN, userId: USER_ID } },
+			});
+
+			if (existingBook) {
+				await prisma.book.update({
+					where: { ISBN_userId: { ISBN: book.ISBN, userId: USER_ID } },
+					data: {
+						ISBN: book.ISBN,
+						title: book.title,
+						googleTitle: book.googleTitle,
+						googleSubTitle: book.googleSubtitle,
+						googleDescription: book.googleDescription,
+						googleAuthors: book.googleAuthors,
+						googleImgSrc: book.googleImgSrc,
+						googleHref: book.googleHref,
+						markdown,
+						rating: book?.rating,
+						tags: book?.tags,
+						userId: USER_ID,
+						status: "UNEXPORTED",
+						exportedAt: new Date(),
+					},
+				});
+			} else {
+				console.log("NEW BOOK", book);
+				await prisma.book.create({
+					data: {
+						id: randomUUIDv7(),
+						ISBN: book.ISBN,
+						title: book.title,
+						googleTitle: book.googleTitle,
+						googleSubTitle: book.googleSubtitle,
+						googleDescription: book.googleDescription,
+						googleAuthors: book.googleAuthors,
+						googleImgSrc: book.googleImgSrc,
+						googleHref: book.googleHref,
+						markdown,
+						rating: book?.rating,
+						tags: book?.tags,
+						userId: USER_ID,
+						status: "EXPORTED",
+						createdAt: new Date(),
+						exportedAt: new Date(),
+					},
+				});
+			}
+		}),
+	);
+	console.log("total books:", bookData.length);
+	console.log("Added books to the database");
+}
+
+async function addImages() {
+	const USER_ID = process.env.USER_ID;
+	if (!USER_ID) throw new Error("Env not set.");
+
+	const path = "dump";
+	const imagesDirectory = join(process.cwd(), "image", path);
+
+	const slugs = getAllSlugs(imagesDirectory);
+	await Promise.all(
+		slugs.map(async (slug) => {
+			const uint8ArrayImage = fs.readFileSync(join(imagesDirectory, slug));
+			const metadata = await sharp(uint8ArrayImage).metadata();
+
+			const optimizedUint8ArrayImage = await optimizeImage(uint8ArrayImage);
+
+			const originalPath = `${ORIGINAL_IMAGE_PATH}/${slug}`;
+			const thumbnailPath = `${THUMBNAIL_IMAGE_PATH}/${slug}`;
+
+			// Check if objects already exist before uploading
+			try {
+				await minioClient.statObject(MINIO_BUCKET_NAME ?? "", originalPath);
+				console.log(`Original image already exists: ${originalPath}`);
+			} catch (_error) {
+				try {
+					console.log(`adding image: ${originalPath}`);
+					// Object doesn't exist, upload it
+					await minioClient.putObject(
+						MINIO_BUCKET_NAME ?? "",
+						originalPath,
+						uint8ArrayImage,
+					);
+				} catch (_error) {
+					console.error("Unexpected error occurred");
+				}
+			}
+
+			try {
+				await minioClient.statObject(MINIO_BUCKET_NAME ?? "", thumbnailPath);
+				console.log(`Thumbnail image already exists: ${thumbnailPath}`);
+			} catch (_error) {
+				try {
+					// Object doesn't exist, upload it
+					await minioClient.putObject(
+						MINIO_BUCKET_NAME ?? "",
+						thumbnailPath,
+						optimizedUint8ArrayImage,
+					);
+				} catch (_error) {
+					console.error("Unexpected error occurred");
+				}
+			}
+
+			const existingImage = await prisma.image.findUnique({
+				where: { path_userId: { path: slug, userId: USER_ID } },
+			});
+
+			if (existingImage) {
+				await prisma.image.update({
+					where: { path_userId: { path: slug, userId: USER_ID } },
+					data: {
+						path: slug,
+						contentType: metadata.format ?? "",
+						width: metadata.width,
+						height: metadata.height,
+						fileSize: metadata.size,
+						userId: USER_ID,
+						status: "EXPORTED",
+						exportedAt: new Date(),
+					},
+				});
+			} else {
+				console.log("NEW IMAGE", slug);
+				await prisma.image.create({
+					data: {
+						id: randomUUIDv7(),
+						path: slug,
+						contentType: metadata.format ?? "",
+						width: metadata.width,
+						height: metadata.height,
+						fileSize: metadata.size,
+						userId: USER_ID,
+						status: "UNEXPORTED",
+						createdAt: new Date(),
+						exportedAt: new Date(),
+					},
+				});
+			}
+		}),
+	);
+	console.log("Added images to the database");
+}
+
+async function addArticles() {
+	const userId = makeUserId(process.env.USER_ID ?? "");
+
+	const path = "article";
+	const contentsDirectory = join(process.cwd(), "json", path);
+
+	const slugs = getAllSlugs(contentsDirectory);
+	const articlesDomainService = new ArticlesDomainService(
+		articlesQueryRepository,
+	);
+
+	await Promise.all(
+		slugs.map(async (slug) => {
+			const json = getJsonBySlug(slug, contentsDirectory);
+			let category = await prisma.category.findUnique({
+				where: { name_userId: { name: json.heading, userId } },
+			});
+
+			if (category) {
+				category = await prisma.category.update({
+					where: { name_userId: { name: json.heading, userId } },
+					data: { name: json.heading, userId },
+				});
+			} else {
+				category = await prisma.category.create({
+					data: {
+						id: randomUUIDv7(),
+						name: json.heading,
+						userId,
+						createdAt: new Date(),
+					},
+				});
+			}
+			json.body.map(
+				async (item: {
+					url: string;
+					title: string;
+					quote: string | null;
+					ogImageUrl: string | null;
+					ogTitle: string | null;
+					ogDescription: string | null;
+				}) => {
+					const url = makeUrl(item.url);
+
+					const { status, data } =
+						await articlesDomainService.changeArticleStatus(
+							url,
+							makeCategoryName(category.name),
+							userId,
+							makeArticleTitle(item.title),
+							makeQuote(item.quote),
+							makeOgTitle(item.ogTitle),
+							makeOgDescription(item.ogDescription),
+							makeOgImageUrl(item.ogImageUrl),
+						);
+
+					switch (status) {
+						case "NEED_CREATE": {
+							console.log("NEW ARTICLE", url);
+							articlesCommandRepository.create(data);
+							return;
+						}
+						case "NEED_UPDATE":
+							console.log("UPDATE ARTICLE", url);
+							articlesCommandRepository.update(url, userId, data);
+							return;
+						case "NO_UPDATE":
+							return;
+						default:
+							status satisfies never;
+					}
+				},
+			);
+		}),
+	);
+	console.log("Added articles to the database");
+}
+
+async function addNotes() {
+	const userId = makeUserId(process.env.USER_ID ?? "");
+
+	const path = "note";
+	const contentsDirectory = join(process.cwd(), "markdown", path);
+
+	const slugs = getAllSlugs(contentsDirectory);
+	const notesDomainService = new NotesDomainService(notesQueryRepository);
+
+	await Promise.all(
+		slugs.map(async (slug) => {
+			const title = makeNoteTitle(slug.replace(/\.md$/, ""));
+			const markdown = makeMarkdown(getMarkdownBySlug(slug, contentsDirectory));
+
+			const { status, data } = await notesDomainService.changeNoteStatus(
+				title,
+				userId,
+				markdown,
+			);
+			switch (status) {
+				case "NEED_CREATE": {
+					console.log("NEW NOTE", title);
+					notesCommandRepository.create(data);
+					return;
+				}
+				case "NEED_UPDATE":
+					console.log("UPDATE NOTE", title);
+					notesCommandRepository.update(title, userId, data);
+					return;
+				case "NO_UPDATE":
+					return;
+				default:
+					status satisfies never;
+			}
+		}),
+	);
+	console.log("Added notes to the database");
+}
+
+async function main() {
+	try {
+		await addArticles();
+		await addNotes();
+		await addBooks();
+		await addImages();
+	} catch (error) {
+		console.error(error);
+		process.exit(1);
+	} finally {
+		await prisma.$disconnect();
+	}
+}
+
+main();

--- a/src/application-services/articles/add-article.test.ts
+++ b/src/application-services/articles/add-article.test.ts
@@ -16,7 +16,7 @@ import {
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { articlesCommandRepository } from "@/infrastructures/articles/repositories/articles-command-repository";
@@ -109,7 +109,7 @@ describe("addArticle", () => {
 			categoryName: makeCategoryName("tech"),
 			categoryId: makeId("01933f5c-9df0-7001-8123-456789abcde0"),
 			userId: makeUserId("user-123"),
-			status: makeStatus("UNEXPORTED"),
+			status: "UNEXPORTED",
 			createdAt: makeCreatedAt(),
 		} as const;
 
@@ -126,7 +126,7 @@ describe("addArticle", () => {
 		);
 		expect(articleEntity.create).toHaveBeenCalled();
 		expect(articlesCommandRepository.create).toHaveBeenCalledWith(mockArticle);
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("articles", status, "user-123"),
 		);

--- a/src/application-services/articles/add-article.ts
+++ b/src/application-services/articles/add-article.ts
@@ -11,7 +11,6 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import { articleEntity } from "@/domains/articles/entities/article-entity";
 import { ArticlesDomainService } from "@/domains/articles/services/articles-domain-service";
-import { makeStatus } from "@/domains/common/entities/common-entity";
 import { articlesCommandRepository } from "@/infrastructures/articles/repositories/articles-command-repository";
 import { articlesQueryRepository } from "@/infrastructures/articles/repositories/articles-query-repository";
 import { parseAddArticleFormData } from "./helpers/form-data-parser";
@@ -45,9 +44,8 @@ export async function addArticle(formData: FormData): Promise<ServerAction> {
 		// Persist
 		await articlesCommandRepository.create(article);
 
-		const status = makeStatus("UNEXPORTED");
-		revalidateTag(buildContentCacheTag("articles", status, userId));
-		revalidateTag(buildCountCacheTag("articles", status, userId));
+		revalidateTag(buildContentCacheTag("articles", article.status, userId));
+		revalidateTag(buildCountCacheTag("articles", article.status, userId));
 
 		revalidateTag("categories");
 

--- a/src/application-services/articles/delete-article.test.ts
+++ b/src/application-services/articles/delete-article.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import {
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { articlesCommandRepository } from "@/infrastructures/articles/repositories/articles-command-repository";
@@ -54,9 +54,9 @@ describe("deleteArticle", () => {
 		expect(articlesCommandRepository.deleteById).toHaveBeenCalledWith(
 			makeId(testId),
 			makeUserId("test-user-id"),
-			makeStatus("UNEXPORTED"),
+			"UNEXPORTED",
 		);
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("articles", status, "test-user-id"),
 		);
@@ -88,7 +88,7 @@ describe("deleteArticle", () => {
 		expect(articlesCommandRepository.deleteById).toHaveBeenCalledWith(
 			makeId(testId),
 			makeUserId("test-user-id"),
-			makeStatus("UNEXPORTED"),
+			"UNEXPORTED",
 		);
 		expect(wrapServerSideErrorForClient).toHaveBeenCalledWith(mockError);
 	});

--- a/src/application-services/articles/delete-article.ts
+++ b/src/application-services/articles/delete-article.ts
@@ -11,7 +11,7 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import {
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { articlesCommandRepository } from "@/infrastructures/articles/repositories/articles-command-repository";
@@ -23,7 +23,7 @@ export async function deleteArticle(id: string): Promise<ServerAction> {
 	try {
 		const userId = await getSelfId();
 
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		await articlesCommandRepository.deleteById(
 			makeId(id),
 			makeUserId(userId),

--- a/src/application-services/books/add-books.test.ts
+++ b/src/application-services/books/add-books.test.ts
@@ -14,7 +14,7 @@ import {
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { booksCommandRepository } from "@/infrastructures/books/repositories/books-command-repository";
@@ -94,7 +94,7 @@ describe("addBooks", () => {
 			ISBN: makeISBN("978-4-06-519981-0"),
 			title: makeBookTitle("Test Book"),
 			userId: makeUserId("user-123"),
-			status: makeStatus("UNEXPORTED"),
+			status: "UNEXPORTED",
 			createdAt: makeCreatedAt(),
 		} as const;
 
@@ -115,7 +115,7 @@ describe("addBooks", () => {
 			userId: makeUserId("user-123"),
 		});
 		expect(booksCommandRepository.create).toHaveBeenCalledWith(mockBook);
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("books", status, "user-123"),
 		);

--- a/src/application-services/books/add-books.ts
+++ b/src/application-services/books/add-books.ts
@@ -11,7 +11,6 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import { bookEntity } from "@/domains/books/entities/books-entity";
 import { BooksDomainService } from "@/domains/books/services/books-domain-service";
-import { makeStatus } from "@/domains/common/entities/common-entity";
 import { booksCommandRepository } from "@/infrastructures/books/repositories/books-command-repository";
 import { booksQueryRepository } from "@/infrastructures/books/repositories/books-query-repository";
 import { parseAddBooksFormData } from "./helpers/form-data-parser";
@@ -41,9 +40,9 @@ export async function addBooks(formData: FormData): Promise<ServerAction> {
 		// Persist
 		await booksCommandRepository.create(book);
 
-		const status = makeStatus("UNEXPORTED");
-		revalidateTag(buildContentCacheTag("books", status, userId));
-		revalidateTag(buildCountCacheTag("books", status, userId));
+		// Cache invalidation
+		revalidateTag(buildContentCacheTag("books", book.status, userId));
+		revalidateTag(buildCountCacheTag("books", book.status, userId));
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/books/delete-books.test.ts
+++ b/src/application-services/books/delete-books.test.ts
@@ -20,7 +20,8 @@ describe("deleteBooks", () => {
 		errorModule.wrapServerSideErrorForClient as Mock;
 	const mockMakeId = commonEntityModule.makeId as Mock;
 	const mockMakeUserId = commonEntityModule.makeUserId as Mock;
-	const mockMakeStatus = commonEntityModule.makeStatus as Mock;
+	const mockMakeUnexportedStatus =
+		commonEntityModule.makeUnexportedStatus as Mock;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -28,7 +29,7 @@ describe("deleteBooks", () => {
 
 		mockMakeId.mockImplementation((id) => id);
 		mockMakeUserId.mockImplementation((userId) => userId);
-		mockMakeStatus.mockImplementation((status) => status);
+		mockMakeUnexportedStatus.mockImplementation(() => "UNEXPORTED");
 	});
 
 	test("should successfully delete a book when user has permission", async () => {

--- a/src/application-services/books/delete-books.ts
+++ b/src/application-services/books/delete-books.ts
@@ -11,7 +11,7 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import {
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { booksCommandRepository } from "@/infrastructures/books/repositories/books-command-repository";
@@ -23,7 +23,7 @@ export async function deleteBooks(id: string): Promise<ServerAction> {
 	try {
 		const userId = await getSelfId();
 
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		await booksCommandRepository.deleteById(
 			makeId(id),
 			makeUserId(userId),

--- a/src/application-services/images/add-image.test.ts
+++ b/src/application-services/images/add-image.test.ts
@@ -5,7 +5,7 @@ import {
 	buildContentCacheTag,
 	buildCountCacheTag,
 } from "@/common/utils/cache-tag-builder";
-import { makeStatus } from "@/domains/common/entities/common-entity";
+import { makeUnexportedStatus } from "@/domains/common/entities/common-entity";
 import { imagesCommandRepository } from "@/infrastructures/images/repositories/images-command-repository";
 import { imagesQueryRepository } from "@/infrastructures/images/repositories/images-query-repository";
 import { addImage } from "./add-image";
@@ -80,7 +80,7 @@ describe("addImage", () => {
 
 		expect(imagesCommandRepository.uploadToStorage).toHaveBeenCalledTimes(2);
 		expect(imagesCommandRepository.create).toHaveBeenCalled();
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("images", status, "user-id"),
 		);

--- a/src/application-services/images/add-image.ts
+++ b/src/application-services/images/add-image.ts
@@ -9,7 +9,6 @@ import {
 	buildContentCacheTag,
 	buildCountCacheTag,
 } from "@/common/utils/cache-tag-builder";
-import { makeStatus } from "@/domains/common/entities/common-entity";
 import { imageEntity } from "@/domains/images/entities/image-entity";
 import { imagesCommandRepository } from "@/infrastructures/images/repositories/images-command-repository";
 import { parseAddImageFormData } from "./helpers/form-data-parser";
@@ -47,9 +46,9 @@ export async function addImage(formData: FormData): Promise<ServerAction> {
 		);
 		await imagesCommandRepository.create(image);
 
-		const status = makeStatus("UNEXPORTED");
-		revalidateTag(buildContentCacheTag("images", status, userId));
-		revalidateTag(buildCountCacheTag("images", status, userId));
+		// Cache invalidation
+		revalidateTag(buildContentCacheTag("images", image.status, userId));
+		revalidateTag(buildCountCacheTag("images", image.status, userId));
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/images/delete-image.ts
+++ b/src/application-services/images/delete-image.ts
@@ -9,7 +9,7 @@ import {
 	buildContentCacheTag,
 	buildCountCacheTag,
 } from "@/common/utils/cache-tag-builder";
-import { makeStatus } from "@/domains/common/entities/common-entity";
+import { makeUnexportedStatus } from "@/domains/common/entities/common-entity";
 import { imagesCommandRepository } from "@/infrastructures/images/repositories/images-command-repository";
 
 export async function deleteImage(id: string): Promise<ServerAction> {
@@ -19,7 +19,7 @@ export async function deleteImage(id: string): Promise<ServerAction> {
 	try {
 		const userId = await getSelfId();
 
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		await imagesCommandRepository.deleteById(id, userId, status);
 
 		revalidateTag(buildContentCacheTag("images", status, userId));

--- a/src/application-services/images/get-images.test.ts
+++ b/src/application-services/images/get-images.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { makeStatus } from "@/domains/common/entities/common-entity";
 import { imagesQueryRepository } from "@/infrastructures/images/repositories/images-query-repository";
 import {
 	getExportedImages,
@@ -185,7 +184,7 @@ describe("get-images", () => {
 		test("should return count of images by status", async () => {
 			vi.mocked(imagesQueryRepository.count).mockResolvedValue(25);
 
-			const result = await getImagesCount(makeStatus("EXPORTED"));
+			const result = await getImagesCount("EXPORTED");
 
 			expect(imagesQueryRepository.count).toHaveBeenCalledWith(
 				"test-user-id",
@@ -197,7 +196,7 @@ describe("get-images", () => {
 		test("should return 0 for empty collection", async () => {
 			vi.mocked(imagesQueryRepository.count).mockResolvedValue(0);
 
-			const result = await getImagesCount(makeStatus("UNEXPORTED"));
+			const result = await getImagesCount("UNEXPORTED");
 
 			expect(result).toEqual(0);
 		});
@@ -207,7 +206,7 @@ describe("get-images", () => {
 				new Error("Database error"),
 			);
 
-			await expect(getImagesCount(makeStatus("EXPORTED"))).rejects.toThrow(
+			await expect(getImagesCount("EXPORTED")).rejects.toThrow(
 				"Database error",
 			);
 		});

--- a/src/application-services/images/helpers/form-data-parser.test.ts
+++ b/src/application-services/images/helpers/form-data-parser.test.ts
@@ -6,7 +6,7 @@ import {
 	makeFileSize,
 	makeOriginalBuffer,
 	makePath,
-	makeThumbnailBuffer,
+	makeThumbnailBufferFromFile,
 } from "@/domains/images/entities/image-entity";
 import { parseAddImageFormData } from "./form-data-parser";
 
@@ -20,7 +20,7 @@ const mockMakePath = vi.mocked(makePath);
 const mockMakeContentType = vi.mocked(makeContentType);
 const mockMakeFileSize = vi.mocked(makeFileSize);
 const mockMakeOriginalBuffer = vi.mocked(makeOriginalBuffer);
-const mockMakeThumbnailBuffer = vi.mocked(makeThumbnailBuffer);
+const mockMakeThumbnailBuffer = vi.mocked(makeThumbnailBufferFromFile);
 
 describe("parseAddImageFormData", () => {
 	beforeEach(() => {

--- a/src/application-services/images/helpers/form-data-parser.ts
+++ b/src/application-services/images/helpers/form-data-parser.ts
@@ -5,7 +5,7 @@ import {
 	makeFileSize,
 	makeOriginalBuffer,
 	makePath,
-	makeThumbnailBuffer,
+	makeThumbnailBufferFromFile,
 } from "@/domains/images/entities/image-entity";
 
 export const parseAddImageFormData = async (
@@ -20,6 +20,6 @@ export const parseAddImageFormData = async (
 		contentType: makeContentType(file.type),
 		fileSize: makeFileSize(file.size),
 		originalBuffer: await makeOriginalBuffer(file),
-		thumbnailBuffer: await makeThumbnailBuffer(file),
+		thumbnailBuffer: await makeThumbnailBufferFromFile(file),
 	};
 };

--- a/src/application-services/notes/add-note.test.ts
+++ b/src/application-services/notes/add-note.test.ts
@@ -8,13 +8,14 @@ import {
 	buildCountCacheTag,
 } from "@/common/utils/cache-tag-builder";
 import {
-	makeStatus,
+	makeCreatedAt,
+	makeId,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import {
 	makeMarkdown,
 	makeNoteTitle,
-	type Note,
 	noteEntity,
 } from "@/domains/notes/entities/note-entity";
 import { notesCommandRepository } from "@/infrastructures/notes/repositories/notes-command-repository";
@@ -80,11 +81,12 @@ describe("addNote", () => {
 		vi.mocked(getSelfId).mockResolvedValue("user-123");
 
 		const mockNote = {
-			title: "Example Note",
-			markdown: "sample markdown",
-			userId: "user-123",
-			status: "UNEXPORTED",
-			id: "01234567-89ab-7def-9123-456789abcdef",
+			title: makeNoteTitle("Example Note"),
+			markdown: makeMarkdown("sample markdown"),
+			userId: makeUserId("user-123"),
+			status: "UNEXPORTED" as const,
+			id: makeId("01234567-89ab-7def-9123-456789abcdef"),
+			createdAt: makeCreatedAt(),
 		};
 
 		vi.mocked(parseAddNoteFormData).mockReturnValue({
@@ -92,7 +94,7 @@ describe("addNote", () => {
 			markdown: makeMarkdown("sample markdown"),
 			userId: makeUserId("user-123"),
 		});
-		vi.mocked(noteEntity.create).mockReturnValue(mockNote as Note);
+		vi.mocked(noteEntity.create).mockReturnValue(mockNote);
 		mockEnsureNoDuplicate.mockResolvedValue(undefined);
 		vi.mocked(notesCommandRepository.create).mockResolvedValue();
 
@@ -106,7 +108,7 @@ describe("addNote", () => {
 		expect(mockEnsureNoDuplicate).toHaveBeenCalled();
 		expect(vi.mocked(noteEntity.create)).toHaveBeenCalled();
 		expect(notesCommandRepository.create).toHaveBeenCalledWith(mockNote);
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("notes", status, "user-123"),
 		);

--- a/src/application-services/notes/add-note.ts
+++ b/src/application-services/notes/add-note.ts
@@ -9,7 +9,6 @@ import {
 	buildContentCacheTag,
 	buildCountCacheTag,
 } from "@/common/utils/cache-tag-builder";
-import { makeStatus } from "@/domains/common/entities/common-entity";
 import { noteEntity } from "@/domains/notes/entities/note-entity";
 import { NotesDomainService } from "@/domains/notes/services/notes-domain-service";
 import { notesCommandRepository } from "@/infrastructures/notes/repositories/notes-command-repository";
@@ -38,9 +37,8 @@ export async function addNote(formData: FormData): Promise<ServerAction> {
 		await notesCommandRepository.create(note);
 
 		// Cache invalidation
-		const status = makeStatus("UNEXPORTED");
-		revalidateTag(buildContentCacheTag("notes", status, userId));
-		revalidateTag(buildCountCacheTag("notes", status, userId));
+		revalidateTag(buildContentCacheTag("notes", note.status, userId));
+		revalidateTag(buildCountCacheTag("notes", note.status, userId));
 
 		return { success: true, message: "inserted" };
 	} catch (error) {

--- a/src/application-services/notes/delete-note.test.ts
+++ b/src/application-services/notes/delete-note.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import {
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { notesCommandRepository } from "@/infrastructures/notes/repositories/notes-command-repository";
@@ -54,9 +54,9 @@ describe("deleteNote", () => {
 		expect(notesCommandRepository.deleteById).toHaveBeenCalledWith(
 			makeId(testId),
 			makeUserId("test-user-id"),
-			makeStatus("UNEXPORTED"),
+			"UNEXPORTED",
 		);
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		expect(revalidateTag).toHaveBeenCalledWith(
 			buildContentCacheTag("notes", status, "test-user-id"),
 		);
@@ -86,7 +86,7 @@ describe("deleteNote", () => {
 		expect(notesCommandRepository.deleteById).toHaveBeenCalledWith(
 			makeId(testId),
 			makeUserId("test-user-id"),
-			makeStatus("UNEXPORTED"),
+			"UNEXPORTED",
 		);
 		expect(wrapServerSideErrorForClient).toHaveBeenCalledWith(mockError);
 	});

--- a/src/application-services/notes/delete-note.ts
+++ b/src/application-services/notes/delete-note.ts
@@ -11,7 +11,7 @@ import {
 } from "@/common/utils/cache-tag-builder";
 import {
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import { notesCommandRepository } from "@/infrastructures/notes/repositories/notes-command-repository";
@@ -23,7 +23,7 @@ export async function deleteNote(id: string): Promise<ServerAction> {
 	try {
 		const userId = await getSelfId();
 
-		const status = makeStatus("UNEXPORTED");
+		const status = makeUnexportedStatus();
 		await notesCommandRepository.deleteById(
 			makeId(id),
 			makeUserId(userId),

--- a/src/domains/articles/events/article-updated-event.ts
+++ b/src/domains/articles/events/article-updated-event.ts
@@ -1,0 +1,26 @@
+import { BaseDomainEvent } from "@/domains/common/events/base-domain-event";
+
+export class ArticleUpdatedEvent extends BaseDomainEvent {
+	constructor(data: {
+		title: string;
+		url: string;
+		quote: string;
+		categoryName: string;
+		userId: string;
+		caller: string;
+	}) {
+		super(
+			"article.updated",
+			{
+				title: data.title,
+				url: data.url,
+				quote: data.quote,
+				categoryName: data.categoryName,
+			},
+			{
+				caller: data.caller,
+				userId: data.userId,
+			},
+		);
+	}
+}

--- a/src/domains/articles/repositories/articles-command-repository.interface.ts
+++ b/src/domains/articles/repositories/articles-command-repository.interface.ts
@@ -3,9 +3,10 @@ import type {
 	Status,
 	UserId,
 } from "@/domains/common/entities/common-entity";
-import type { Article } from "../entities/article-entity";
+import type { UnexportedArticle, Url } from "../entities/article-entity";
 
 export type IArticlesCommandRepository = {
-	create(data: Article): Promise<void>;
+	create(data: UnexportedArticle): Promise<void>;
+	update(url: Url, userId: UserId, data: UnexportedArticle): Promise<void>;
 	deleteById(id: Id, userId: UserId, status: Status): Promise<void>;
 };

--- a/src/domains/articles/repositories/articles-query-repository.interface.ts
+++ b/src/domains/articles/repositories/articles-query-repository.interface.ts
@@ -3,7 +3,21 @@ import type { Url } from "../entities/article-entity";
 import type { ArticlesFindManyParams } from "../types/query-params";
 
 export type IArticlesQueryRepository = {
-	findByUrl(url: Url, userId: UserId): Promise<{} | null>;
+	findByUrl(
+		url: Url,
+		userId: UserId,
+	): Promise<{
+		title: string;
+		url: string;
+		quote: string | null;
+		ogTitle: string | null;
+		ogDescription: string | null;
+		ogImageUrl: string | null;
+		Category: {
+			id: string;
+			name: string;
+		};
+	} | null>;
 	findMany(
 		userId: UserId,
 		status: Status,

--- a/src/domains/articles/services/articles-domain-service.test.ts
+++ b/src/domains/articles/services/articles-domain-service.test.ts
@@ -47,6 +47,11 @@ describe("ArticlesDomainService", () => {
 				userId,
 				title: "Existing Article",
 				status: "UNEXPORTED" as const,
+				quote: "Sample quote",
+				ogTitle: "OG Title",
+				ogDescription: "OG Description",
+				ogImageUrl: "https://example.com/og-image.jpg",
+				Category: { id: "category-id", name: "Tech" },
 			};
 
 			vi.mocked(articlesQueryRepository.findByUrl).mockResolvedValue(

--- a/src/domains/books/entities/books-entity.ts
+++ b/src/domains/books/entities/books-entity.ts
@@ -32,32 +32,35 @@ export const makeBookTitle = (v: string): BookTitle => BookTitle.parse(v);
 
 const GoogleTitle = z.string().nullable().brand<"GoogleTitle">();
 export type GoogleTitle = z.infer<typeof GoogleTitle>;
-export const makeGoogleTitle = (v: string | null): GoogleTitle =>
+export const makeGoogleTitle = (v: string | null | undefined): GoogleTitle =>
 	GoogleTitle.parse(v);
 
 const GoogleSubTitle = z.string().nullable().brand<"GoogleSubTitle">();
 export type GoogleSubTitle = z.infer<typeof GoogleSubTitle>;
-export const makeGoogleSubTitle = (v: string | null): GoogleSubTitle =>
-	GoogleSubTitle.parse(v);
+export const makeGoogleSubTitle = (
+	v: string | null | undefined,
+): GoogleSubTitle => GoogleSubTitle.parse(v);
 
 const GoogleAuthors = z.array(z.string()).nullable().brand<"GoogleAuthors">();
 export type GoogleAuthors = z.infer<typeof GoogleAuthors>;
-export const makeGoogleAuthors = (v: string[] | null): GoogleAuthors =>
-	GoogleAuthors.parse(v);
+export const makeGoogleAuthors = (
+	v: string[] | null | undefined,
+): GoogleAuthors => GoogleAuthors.parse(v);
 
 const GoogleDescription = z.string().nullable().brand<"GoogleDescription">();
 export type GoogleDescription = z.infer<typeof GoogleDescription>;
-export const makeGoogleDescription = (v: string | null): GoogleDescription =>
-	GoogleDescription.parse(v);
+export const makeGoogleDescription = (
+	v: string | null | undefined,
+): GoogleDescription => GoogleDescription.parse(v);
 
 const GoogleImgSrc = z.string().nullable().brand<"GoogleImgSrc">();
 export type GoogleImgSrc = z.infer<typeof GoogleImgSrc>;
-export const makeGoogleImgSrc = (v: string | null): GoogleImgSrc =>
+export const makeGoogleImgSrc = (v: string | null | undefined): GoogleImgSrc =>
 	GoogleImgSrc.parse(v);
 
 const GoogleHref = z.string().nullable().brand<"GoogleHref">();
 export type GoogleHref = z.infer<typeof GoogleHref>;
-export const makeGoogleHref = (v: string | null): GoogleHref =>
+export const makeGoogleHref = (v: string | null | undefined): GoogleHref =>
 	GoogleHref.parse(v);
 
 const BookMarkdown = z.string().nullable().brand<"BookMarkdown">();

--- a/src/domains/books/entities/books-entity.ts
+++ b/src/domains/books/entities/books-entity.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import {
 	CreatedAt,
-	ExportedAt,
+	ExportedStatus,
 	Id,
 	makeCreatedAt,
+	makeExportedStatus,
 	makeId,
-	makeStatus,
-	Status,
+	UnexportedStatus,
 	UserId,
 } from "@/domains/common/entities/common-entity";
 import { createEntityWithErrorHandling } from "@/domains/common/services/entity-factory";
@@ -27,52 +27,51 @@ const BookTitle = z
 	.min(1, { message: "required" })
 	.max(256, { message: "tooLong" })
 	.brand<"BookTitle">();
-type BookTitle = z.infer<typeof BookTitle>;
+export type BookTitle = z.infer<typeof BookTitle>;
 export const makeBookTitle = (v: string): BookTitle => BookTitle.parse(v);
 
 const GoogleTitle = z.string().nullable().brand<"GoogleTitle">();
-type GoogleTitle = z.infer<typeof GoogleTitle>;
+export type GoogleTitle = z.infer<typeof GoogleTitle>;
 export const makeGoogleTitle = (v: string | null): GoogleTitle =>
 	GoogleTitle.parse(v);
 
 const GoogleSubTitle = z.string().nullable().brand<"GoogleSubTitle">();
-type GoogleSubTitle = z.infer<typeof GoogleSubTitle>;
+export type GoogleSubTitle = z.infer<typeof GoogleSubTitle>;
 export const makeGoogleSubTitle = (v: string | null): GoogleSubTitle =>
 	GoogleSubTitle.parse(v);
 
 const GoogleAuthors = z.array(z.string()).nullable().brand<"GoogleAuthors">();
-type GoogleAuthors = z.infer<typeof GoogleAuthors>;
+export type GoogleAuthors = z.infer<typeof GoogleAuthors>;
 export const makeGoogleAuthors = (v: string[] | null): GoogleAuthors =>
 	GoogleAuthors.parse(v);
 
 const GoogleDescription = z.string().nullable().brand<"GoogleDescription">();
-type GoogleDescription = z.infer<typeof GoogleDescription>;
+export type GoogleDescription = z.infer<typeof GoogleDescription>;
 export const makeGoogleDescription = (v: string | null): GoogleDescription =>
 	GoogleDescription.parse(v);
 
 const GoogleImgSrc = z.string().nullable().brand<"GoogleImgSrc">();
-type GoogleImgSrc = z.infer<typeof GoogleImgSrc>;
+export type GoogleImgSrc = z.infer<typeof GoogleImgSrc>;
 export const makeGoogleImgSrc = (v: string | null): GoogleImgSrc =>
 	GoogleImgSrc.parse(v);
 
 const GoogleHref = z.string().nullable().brand<"GoogleHref">();
-type GoogleHref = z.infer<typeof GoogleHref>;
+export type GoogleHref = z.infer<typeof GoogleHref>;
 export const makeGoogleHref = (v: string | null): GoogleHref =>
 	GoogleHref.parse(v);
 
 const BookMarkdown = z.string().nullable().brand<"BookMarkdown">();
-type BookMarkdown = z.infer<typeof BookMarkdown>;
+export type BookMarkdown = z.infer<typeof BookMarkdown>;
 export const makeBookMarkdown = (v: string | null): BookMarkdown =>
 	BookMarkdown.parse(v);
 
 // Entities
 
-const book = z.object({
+const Base = z.object({
 	id: Id,
 	userId: UserId,
 	ISBN: ISBN,
 	title: BookTitle,
-	status: Status,
 	googleTitle: GoogleTitle.optional(),
 	googleSubTitle: GoogleSubTitle.optional(),
 	googleAuthors: GoogleAuthors.optional(),
@@ -81,9 +80,13 @@ const book = z.object({
 	googleHref: GoogleHref.optional(),
 	markdown: BookMarkdown.optional(),
 	createdAt: CreatedAt,
-	exportedAt: ExportedAt,
 });
-export type Book = Readonly<z.infer<typeof book>>;
+
+export const UnexportedBook = Base.extend({ status: UnexportedStatus });
+export type UnexportedBook = Readonly<z.infer<typeof UnexportedBook>>;
+
+const ExportedBook = Base.extend(ExportedStatus.shape);
+type ExportedBook = Readonly<z.infer<typeof ExportedBook>>;
 
 type CreateBookArgs = Readonly<{
 	userId: UserId;
@@ -91,15 +94,42 @@ type CreateBookArgs = Readonly<{
 	title: BookTitle;
 }>;
 
+type UpdateBookArgs = Readonly<{
+	title: BookTitle;
+	googleTitle: GoogleTitle;
+	googleSubTitle: GoogleSubTitle;
+	googleAuthors: GoogleAuthors;
+	googleDescription: GoogleDescription;
+	googleImgSrc: GoogleImgSrc;
+	googleHref: GoogleHref;
+	markdown: BookMarkdown;
+}>;
+
 export const bookEntity = {
-	create: (args: CreateBookArgs): Book => {
+	create: (args: CreateBookArgs): UnexportedBook => {
 		return createEntityWithErrorHandling(() =>
 			Object.freeze({
 				id: makeId(),
-				status: makeStatus("UNEXPORTED"),
+				status: "UNEXPORTED",
 				createdAt: makeCreatedAt(),
 				...args,
 			}),
 		);
+	},
+
+	update: (book: UnexportedBook, args: UpdateBookArgs): UnexportedBook => {
+		return createEntityWithErrorHandling(() =>
+			Object.freeze({ ...book, ...args }),
+		);
+	},
+
+	export: (book: UnexportedBook): ExportedBook => {
+		return createEntityWithErrorHandling(() => {
+			const exportedStatus = makeExportedStatus();
+			return Object.freeze({
+				...book,
+				...exportedStatus,
+			});
+		});
 	},
 };

--- a/src/domains/books/events/book-updated-event.ts
+++ b/src/domains/books/events/book-updated-event.ts
@@ -1,0 +1,22 @@
+import { BaseDomainEvent } from "@/domains/common/events/base-domain-event";
+
+export class BookUpdatedEvent extends BaseDomainEvent {
+	constructor(data: {
+		ISBN: string;
+		title: string;
+		userId: string;
+		caller: string;
+	}) {
+		super(
+			"book.updated",
+			{
+				ISBN: data.ISBN,
+				title: data.title,
+			},
+			{
+				caller: data.caller,
+				userId: data.userId,
+			},
+		);
+	}
+}

--- a/src/domains/books/repositories/books-command-repository.interface.ts
+++ b/src/domains/books/repositories/books-command-repository.interface.ts
@@ -9,4 +9,5 @@ export type IBooksCommandRepository = {
 	create(data: UnexportedBook): Promise<void>;
 	update(ISBN: ISBN, userId: UserId, data: UnexportedBook): Promise<void>;
 	deleteById(id: Id, userId: UserId, status: Status): Promise<void>;
+	fetchBookFromGitHub(): Promise<UnexportedBook[]>;
 };

--- a/src/domains/books/repositories/books-command-repository.interface.ts
+++ b/src/domains/books/repositories/books-command-repository.interface.ts
@@ -3,9 +3,10 @@ import type {
 	Status,
 	UserId,
 } from "@/domains/common/entities/common-entity";
-import type { Book } from "../entities/books-entity";
+import type { ISBN, UnexportedBook } from "../entities/books-entity";
 
 export type IBooksCommandRepository = {
-	create(data: Book): Promise<void>;
+	create(data: UnexportedBook): Promise<void>;
+	update(ISBN: ISBN, userId: UserId, data: UnexportedBook): Promise<void>;
 	deleteById(id: Id, userId: UserId, status: Status): Promise<void>;
 };

--- a/src/domains/books/services/books-domain-service.ts
+++ b/src/domains/books/services/books-domain-service.ts
@@ -1,8 +1,24 @@
 import "server-only";
-import { DuplicateError } from "@/common/error/error-classes";
+import { DuplicateError, UnexpectedError } from "@/common/error/error-classes";
 import type { IBooksQueryRepository } from "@/domains/books/repositories/books-query-repository.interface";
-import type { UserId } from "@/domains/common/entities/common-entity";
-import type { ISBN } from "../entities/books-entity";
+import {
+	makeUserId,
+	type UserId,
+} from "@/domains/common/entities/common-entity";
+import {
+	type BookMarkdown,
+	type BookTitle,
+	bookEntity,
+	type GoogleAuthors,
+	type GoogleDescription,
+	type GoogleHref,
+	type GoogleImgSrc,
+	type GoogleSubTitle,
+	type GoogleTitle,
+	type ISBN,
+	makeISBN,
+	UnexportedBook,
+} from "../entities/books-entity";
 
 async function ensureNoDuplicateBook(
 	booksQueryRepository: IBooksQueryRepository,
@@ -13,10 +29,92 @@ async function ensureNoDuplicateBook(
 	if (exists !== null) throw new DuplicateError();
 }
 
+type BookStatus = "NEED_CREATE" | "NEED_UPDATE" | "NO_UPDATE";
+
+async function changeBookStatus(
+	booksQueryRepository: IBooksQueryRepository,
+	ISBN: ISBN,
+	userId: UserId,
+	title: BookTitle,
+	googleTitle: GoogleTitle,
+	googleSubTitle: GoogleSubTitle,
+	googleAuthors: GoogleAuthors,
+	googleDescription: GoogleDescription,
+	googleImgSrc: GoogleImgSrc,
+	googleHref: GoogleHref,
+	markdown: BookMarkdown,
+): Promise<{ status: BookStatus; data: UnexportedBook }> {
+	const data = await booksQueryRepository.findByISBN(
+		makeISBN(ISBN),
+		makeUserId(userId),
+	);
+	if (!data) {
+		return {
+			status: "NEED_CREATE",
+			data: bookEntity.create({ userId, ISBN, title }),
+		};
+	}
+	const newData = UnexportedBook.safeParse(data);
+	if (!newData.success) throw new UnexpectedError();
+
+	if (
+		data.title !== title ||
+		data.googleTitle !== googleTitle ||
+		data.googleSubTitle !== googleSubTitle ||
+		JSON.stringify(data.googleAuthors) !== JSON.stringify(googleAuthors) ||
+		data.googleDescription !== googleDescription ||
+		data.googleImgSrc !== googleImgSrc ||
+		data.googleHref !== googleHref ||
+		data.markdown !== markdown
+	) {
+		return {
+			status: "NEED_UPDATE",
+			data: bookEntity.update(newData.data, {
+				title,
+				googleTitle,
+				googleSubTitle,
+				googleAuthors,
+				googleDescription,
+				googleImgSrc,
+				googleHref,
+				markdown,
+			}),
+		};
+	}
+	return { status: "NO_UPDATE", data: newData.data };
+}
+
 export class BooksDomainService {
 	constructor(private readonly booksQueryRepository: IBooksQueryRepository) {}
 
-	public async ensureNoDuplicate(ISBN: ISBN, userId: UserId): Promise<void> {
+	public async ensureNoDuplicate(ISBN: ISBN, userId: UserId) {
 		return ensureNoDuplicateBook(this.booksQueryRepository, ISBN, userId);
+	}
+
+	public async changeBookStatus(
+		ISBN: ISBN,
+		userId: UserId,
+		title: BookTitle,
+		googleTitle: GoogleTitle,
+		googleSubTitle: GoogleSubTitle,
+		googleAuthors: GoogleAuthors,
+		googleDescription: GoogleDescription,
+		googleImgSrc: GoogleImgSrc,
+		googleHref: GoogleHref,
+		markdown: BookMarkdown,
+	) {
+		return changeBookStatus(
+			this.booksQueryRepository,
+			ISBN,
+			userId,
+			title,
+			googleTitle,
+			googleSubTitle,
+			googleAuthors,
+			googleDescription,
+			googleImgSrc,
+			googleHref,
+			markdown,
+		);
 	}
 }

--- a/src/domains/common/entities/common-entity.ts
+++ b/src/domains/common/entities/common-entity.ts
@@ -3,11 +3,6 @@ import { idGenerator } from "../services/id-generator";
 
 // common value objects
 
-export const Status = z.enum(["UNEXPORTED", "EXPORTED"]).brand<"Status">();
-export type Status = z.infer<typeof Status>;
-export const makeStatus = (v: "UNEXPORTED" | "EXPORTED"): Status =>
-	Status.parse(v);
-
 export const Id = z
 	.uuid({ version: "v7" })
 	.default(() => idGenerator.uuidv7())
@@ -24,8 +19,34 @@ export const makeUserId = (v: string): UserId => UserId.parse(v);
 
 export const CreatedAt = z.date().brand<"CreatedAt">();
 export type CreatedAt = z.infer<typeof CreatedAt>;
-export const makeCreatedAt = (): CreatedAt => CreatedAt.parse(new Date());
+export const makeCreatedAt = (createdAt?: Date): CreatedAt => {
+	if (!createdAt) return CreatedAt.parse(new Date());
+	return CreatedAt.parse(createdAt);
+};
 
-export const ExportedAt = z.date().nullable().optional().brand<"ExportedAt">();
+export const UnexportedStatus = z.literal("UNEXPORTED");
+export type UnexportedStatus = z.infer<typeof UnexportedStatus>;
+export const makeUnexportedStatus = (): UnexportedStatus =>
+	UnexportedStatus.parse("UNEXPORTED");
+
+export const ExportedAt = z.date().brand<"ExportedAt">();
 export type ExportedAt = z.infer<typeof ExportedAt>;
-export const makeExportedAt = (): ExportedAt => ExportedAt.parse(new Date());
+export const makeExportedAt = (exportedAt?: Date): ExportedAt => {
+	if (!exportedAt) return ExportedAt.parse(new Date());
+	return ExportedAt.parse(exportedAt);
+};
+
+export const ExportedStatus = z.object({
+	status: z.literal("EXPORTED"),
+	exportedAt: ExportedAt,
+});
+export type ExportedStatus = z.infer<typeof ExportedStatus>;
+export const makeExportedStatus = (): ExportedStatus =>
+	ExportedStatus.parse({ status: "EXPORTED", exportedAt: new Date() });
+
+export type Status = UnexportedStatus | ExportedStatus["status"];
+
+// Legacy compatibility - will be removed in future
+export const makeStatus = (status: "UNEXPORTED" | "EXPORTED"): Status => {
+	return status as Status;
+};

--- a/src/domains/images/entities/image-entity.ts
+++ b/src/domains/images/entities/image-entity.ts
@@ -58,11 +58,19 @@ export const makeOriginalBuffer = async (file: File) => {
 	return Buffer.from(await file.arrayBuffer());
 };
 
-export const makeThumbnailBuffer = async (file: File) => {
+export const makeThumbnailBufferFromFile = async (file: File) => {
 	const originalBuffer = Buffer.from(await file.arrayBuffer());
 	return await sharp(originalBuffer)
 		.resize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
 		.toBuffer();
+};
+export const makeThumbnailBufferFromBuffer = async (buffer: Buffer) => {
+	return await sharp(buffer)
+		.resize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
+		.toBuffer();
+};
+export const makeMetadata = async (buffer: Buffer) => {
+	return sharp(buffer).metadata();
 };
 
 // Entities

--- a/src/domains/images/events/image-updated-event.ts
+++ b/src/domains/images/events/image-updated-event.ts
@@ -1,0 +1,22 @@
+import { BaseDomainEvent } from "@/domains/common/events/base-domain-event";
+
+export class ImageUpdatedEvent extends BaseDomainEvent {
+	constructor(data: {
+		id: string;
+		path: string;
+		userId: string;
+		caller: string;
+	}) {
+		super(
+			"image.updated",
+			{
+				id: data.id,
+				path: data.path,
+			},
+			{
+				caller: data.caller,
+				userId: data.userId,
+			},
+		);
+	}
+}

--- a/src/domains/images/repositories/images-command-repository.interface.ts
+++ b/src/domains/images/repositories/images-command-repository.interface.ts
@@ -1,8 +1,9 @@
-import type { Status } from "@/domains/common/entities/common-entity";
-import type { Image, Path } from "../entities/image-entity";
+import type { Status, UserId } from "@/domains/common/entities/common-entity";
+import type { Path, UnexportedImage } from "../entities/image-entity";
 
 export type IImagesCommandRepository = {
-	create(data: Image): Promise<void>;
+	create(data: UnexportedImage): Promise<void>;
+	update(path: Path, userId: UserId, data: UnexportedImage): Promise<void>;
 	uploadToStorage(
 		path: Path,
 		buffer: Buffer,

--- a/src/domains/images/repositories/images-query-repository.interface.ts
+++ b/src/domains/images/repositories/images-query-repository.interface.ts
@@ -3,7 +3,19 @@ import type { Path } from "../entities/image-entity";
 import type { ImagesFindManyParams } from "../types/query-params";
 
 export type IImagesQueryRepository = {
-	findByPath(path: Path, userId: UserId): Promise<{} | null>;
+	findByPath(
+		path: Path,
+		userId: UserId,
+	): Promise<{
+		id: string;
+		path: string;
+		contentType: string;
+		fileSize: number | null;
+		width: number | null;
+		height: number | null;
+		tags: string[];
+		description: string | null;
+	} | null>;
 	findMany(
 		userId: UserId,
 		status: Status,

--- a/src/domains/images/repositories/images-query-repository.interface.ts
+++ b/src/domains/images/repositories/images-query-repository.interface.ts
@@ -28,4 +28,5 @@ export type IImagesQueryRepository = {
 		path: string,
 		isThumbnail: boolean,
 	): Promise<NodeJS.ReadableStream>;
+	getFromStorageOrThrow(path: string, isThumbnail: boolean): Promise<void>;
 };

--- a/src/domains/images/services/images-domain-service.ts
+++ b/src/domains/images/services/images-domain-service.ts
@@ -1,0 +1,116 @@
+import "server-only";
+import { DuplicateError, UnexpectedError } from "@/common/error/error-classes";
+import {
+	makeUserId,
+	type UserId,
+} from "@/domains/common/entities/common-entity";
+import type { IImagesQueryRepository } from "@/domains/images/repositories/images-query-repository.interface";
+import {
+	type ContentType,
+	type Description,
+	type FileSize,
+	imageEntity,
+	makePath,
+	type Path,
+	type Pixel,
+	type Tag,
+	UnexportedImage,
+} from "../entities/image-entity";
+
+async function ensureNoDuplicateImage(
+	imagesQueryRepository: IImagesQueryRepository,
+	path: Path,
+	userId: UserId,
+): Promise<void> {
+	const exists = await imagesQueryRepository.findByPath(path, userId);
+	if (exists !== null) throw new DuplicateError();
+}
+
+type ImageStatus = "NEED_CREATE" | "NEED_UPDATE" | "NO_UPDATE";
+
+async function changeImageStatus(
+	imagesQueryRepository: IImagesQueryRepository,
+	path: Path,
+	userId: UserId,
+	contentType: ContentType,
+	fileSize: FileSize,
+	width?: Pixel,
+	height?: Pixel,
+	tags?: Array<Tag>,
+	description?: Description,
+): Promise<{ status: ImageStatus; data: UnexportedImage }> {
+	const data = await imagesQueryRepository.findByPath(
+		makePath(path),
+		makeUserId(userId),
+	);
+	if (!data) {
+		return {
+			status: "NEED_CREATE",
+			data: imageEntity.create({
+				userId,
+				path,
+				contentType,
+				fileSize,
+				width,
+				height,
+				tags,
+				description,
+			}),
+		};
+	}
+	const newData = UnexportedImage.safeParse(data);
+	if (!newData.success) throw new UnexpectedError();
+
+	if (
+		data.contentType !== contentType ||
+		data.fileSize !== fileSize ||
+		data.width !== width ||
+		data.height !== height ||
+		JSON.stringify(data.tags) !== JSON.stringify(tags) ||
+		data.description !== description
+	) {
+		return {
+			status: "NEED_UPDATE",
+			data: imageEntity.update(newData.data, {
+				contentType,
+				fileSize,
+				width,
+				height,
+				tags,
+				description,
+			}),
+		};
+	}
+	return { status: "NO_UPDATE", data: newData.data };
+}
+
+export class ImagesDomainService {
+	constructor(private readonly imagesQueryRepository: IImagesQueryRepository) {}
+
+	public async ensureNoDuplicate(path: Path, userId: UserId) {
+		return ensureNoDuplicateImage(this.imagesQueryRepository, path, userId);
+	}
+
+	public async changeImageStatus(
+		path: Path,
+		userId: UserId,
+		contentType: ContentType,
+		fileSize: FileSize,
+		width?: Pixel,
+		height?: Pixel,
+		tags?: Array<Tag>,
+		description?: Description,
+	) {
+		return changeImageStatus(
+			this.imagesQueryRepository,
+			path,
+			userId,
+			contentType,
+			fileSize,
+			width,
+			height,
+			tags,
+			description,
+		);
+	}
+}

--- a/src/domains/notes/events/note-updated-event.ts
+++ b/src/domains/notes/events/note-updated-event.ts
@@ -1,0 +1,22 @@
+import { BaseDomainEvent } from "@/domains/common/events/base-domain-event";
+
+export class NoteUpdatedEvent extends BaseDomainEvent {
+	constructor(data: {
+		title: string;
+		markdown: string;
+		userId: string;
+		caller: string;
+	}) {
+		super(
+			"note.updated",
+			{
+				title: data.title,
+				markdown: data.markdown,
+			},
+			{
+				caller: data.caller,
+				userId: data.userId,
+			},
+		);
+	}
+}

--- a/src/domains/notes/repositories/notes-command-repository.interface.ts
+++ b/src/domains/notes/repositories/notes-command-repository.interface.ts
@@ -3,9 +3,10 @@ import type {
 	Status,
 	UserId,
 } from "@/domains/common/entities/common-entity";
-import type { Note } from "../entities/note-entity";
+import type { NoteTitle, UnexportedNote } from "../entities/note-entity";
 
 export type INotesCommandRepository = {
-	create(data: Note): Promise<void>;
+	create(data: UnexportedNote): Promise<void>;
+	update(title: NoteTitle, userId: UserId, data: UnexportedNote): Promise<void>;
 	deleteById(id: Id, userId: UserId, status: Status): Promise<void>;
 };

--- a/src/domains/notes/services/notes-domain-service.ts
+++ b/src/domains/notes/services/notes-domain-service.ts
@@ -1,7 +1,16 @@
 import "server-only";
-import { DuplicateError } from "@/common/error/error-classes";
-import type { UserId } from "@/domains/common/entities/common-entity";
-import type { NoteTitle } from "@/domains/notes/entities/note-entity";
+import { DuplicateError, UnexpectedError } from "@/common/error/error-classes";
+import {
+	makeUserId,
+	type UserId,
+} from "@/domains/common/entities/common-entity";
+import {
+	type Markdown,
+	makeNoteTitle,
+	type NoteTitle,
+	noteEntity,
+	UnexportedNote,
+} from "@/domains/notes/entities/note-entity";
 import type { INotesQueryRepository } from "@/domains/notes/repositories/notes-query-repository.interface";
 
 async function ensureNoDuplicateNote(
@@ -15,13 +24,48 @@ async function ensureNoDuplicateNote(
 	}
 }
 
+type NoteStatus = "NEED_CREATE" | "NEED_UPDATE" | "NO_UPDATE";
+
+async function changeNoteStatus(
+	notesQueryRepository: INotesQueryRepository,
+	title: NoteTitle,
+	userId: UserId,
+	markdown: Markdown,
+): Promise<{ status: NoteStatus; data: UnexportedNote }> {
+	const data = await notesQueryRepository.findByTitle(
+		makeNoteTitle(title),
+		makeUserId(userId),
+	);
+	if (!data) {
+		return {
+			status: "NEED_CREATE",
+			data: noteEntity.create({ userId, title, markdown }),
+		};
+	}
+	const newData = UnexportedNote.safeParse(data);
+	if (!newData.success) throw new UnexpectedError();
+
+	if (data.markdown !== markdown) {
+		return {
+			status: "NEED_UPDATE",
+			data: noteEntity.update(newData.data, { title, markdown }),
+		};
+	}
+	return { status: "NO_UPDATE", data: newData.data };
+}
+
 export class NotesDomainService {
 	constructor(private readonly notesQueryRepository: INotesQueryRepository) {}
 
-	public async ensureNoDuplicate(
+	public async ensureNoDuplicate(title: NoteTitle, userId: UserId) {
+		return ensureNoDuplicateNote(this.notesQueryRepository, title, userId);
+	}
+
+	public async changeNoteStatus(
 		title: NoteTitle,
 		userId: UserId,
-	): Promise<void> {
-		return ensureNoDuplicateNote(this.notesQueryRepository, title, userId);
+		markdown: Markdown,
+	) {
+		return changeNoteStatus(this.notesQueryRepository, title, userId, markdown);
 	}
 }

--- a/src/infrastructures/articles/repositories/articles-command-repository.test.ts
+++ b/src/infrastructures/articles/repositories/articles-command-repository.test.ts
@@ -9,7 +9,7 @@ import type { Status } from "@/domains/common/entities/common-entity";
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import prisma from "@/prisma";
@@ -45,7 +45,7 @@ describe("ArticlesCommandRepository", () => {
 				quote: makeQuote("This is a test quote"),
 				userId: makeUserId("user123"),
 				id: makeId("01234567-89ab-7def-9123-456789abcdef"),
-				status: makeStatus("UNEXPORTED"),
+				status: makeUnexportedStatus(),
 				categoryName: makeCategoryName("tech"),
 				categoryId: makeId("01234567-89ab-7def-8123-456789abcde0"),
 				createdAt: makeCreatedAt(),
@@ -80,7 +80,7 @@ describe("ArticlesCommandRepository", () => {
 				categoryId: makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae"),
 				userId: makeUserId("user123"),
 				id: makeId("0198bfc4-444f-71eb-8e78-4005df127ffd"),
-				status: makeStatus("UNEXPORTED"),
+				status: makeUnexportedStatus(),
 				createdAt: makeCreatedAt(),
 			});
 
@@ -100,7 +100,7 @@ describe("ArticlesCommandRepository", () => {
 					quote: makeQuote("This is a test quote"),
 					userId: makeUserId("user123"),
 					id: makeId("01234567-89ab-7def-9123-456789abcdef"),
-					status: makeStatus("UNEXPORTED"),
+					status: makeUnexportedStatus(),
 					categoryName: makeCategoryName("tech"),
 					categoryId: makeId("01234567-89ab-7def-8123-456789abcde0"),
 					createdAt: makeCreatedAt(),
@@ -132,7 +132,7 @@ describe("ArticlesCommandRepository", () => {
 			await articlesCommandRepository.deleteById(
 				makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae"),
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.article.delete).toHaveBeenCalledWith({
@@ -154,7 +154,7 @@ describe("ArticlesCommandRepository", () => {
 				articlesCommandRepository.deleteById(
 					makeId("0198bfc4-444f-71eb-8e78-46840c337877"),
 					makeUserId("user123"),
-					makeStatus("EXPORTED"),
+					"EXPORTED",
 				),
 			).rejects.toThrow("Record not found");
 
@@ -188,7 +188,7 @@ describe("ArticlesCommandRepository", () => {
 			await articlesCommandRepository.deleteById(
 				makeId("0198bfc4-444f-71eb-8e78-4eaeec50cd3e"),
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				makeUnexportedStatus(),
 			);
 
 			expect(prisma.article.delete).toHaveBeenCalledWith({

--- a/src/infrastructures/articles/repositories/articles-query-repository.test.ts
+++ b/src/infrastructures/articles/repositories/articles-query-repository.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import {
-	makeStatus,
-	makeUserId,
-} from "@/domains/common/entities/common-entity";
+import { makeUserId } from "@/domains/common/entities/common-entity";
 import prisma from "@/prisma";
 import {
 	articlesQueryRepository,
@@ -47,7 +44,7 @@ describe("ArticlesQueryRepository", () => {
 
 			const result = await articlesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -91,7 +88,7 @@ describe("ArticlesQueryRepository", () => {
 
 			const result = await articlesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				{},
 			);
 
@@ -131,7 +128,7 @@ describe("ArticlesQueryRepository", () => {
 
 			const result = await articlesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -167,11 +164,7 @@ describe("ArticlesQueryRepository", () => {
 			);
 
 			await expect(
-				articlesQueryRepository.findMany(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-					{},
-				),
+				articlesQueryRepository.findMany(makeUserId("user123"), "EXPORTED", {}),
 			).rejects.toThrow("Database connection error");
 
 			expect(prisma.article.findMany).toHaveBeenCalledWith({
@@ -195,7 +188,7 @@ describe("ArticlesQueryRepository", () => {
 
 			const result = await articlesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.article.count).toHaveBeenCalledWith({
@@ -209,7 +202,7 @@ describe("ArticlesQueryRepository", () => {
 
 			const result = await articlesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				"UNEXPORTED",
 			);
 
 			expect(prisma.article.count).toHaveBeenCalledWith({
@@ -224,10 +217,7 @@ describe("ArticlesQueryRepository", () => {
 			);
 
 			await expect(
-				articlesQueryRepository.count(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				articlesQueryRepository.count(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database count error");
 
 			expect(prisma.article.count).toHaveBeenCalledWith({

--- a/src/infrastructures/articles/repositories/articles-query-repository.ts
+++ b/src/infrastructures/articles/repositories/articles-query-repository.ts
@@ -11,7 +11,15 @@ import prisma from "@/prisma";
 async function findByUrl(url: string, userId: string) {
 	const data = await prisma.article.findUnique({
 		where: { url_userId: { url, userId } },
-		select: { url: true },
+		select: {
+			url: true,
+			Category: true,
+			title: true,
+			ogTitle: true,
+			ogDescription: true,
+			quote: true,
+			ogImageUrl: true,
+		},
 	});
 	return data;
 }

--- a/src/infrastructures/books/repositories/books-command-repository.test.ts
+++ b/src/infrastructures/books/repositories/books-command-repository.test.ts
@@ -13,7 +13,7 @@ import {
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import prisma from "@/prisma";
@@ -51,7 +51,7 @@ describe("BooksCommandRepository", () => {
 				userId: makeUserId("user123"),
 				ISBN: makeISBN("9784123456789"),
 				title: makeBookTitle("Test Book"),
-				status: makeStatus("UNEXPORTED"),
+				status: "UNEXPORTED",
 				createdAt: makeCreatedAt(),
 			});
 
@@ -84,7 +84,7 @@ describe("BooksCommandRepository", () => {
 				userId: makeUserId("user123"),
 				ISBN: makeISBN("9784567890123"),
 				title: makeBookTitle("Complete Book"),
-				status: makeStatus("UNEXPORTED"),
+				status: "UNEXPORTED",
 				markdown: makeBookMarkdown("# Book Review\nThis is a great book."),
 				googleDescription: makeGoogleDescription("Google Description"),
 				googleAuthors: makeGoogleAuthors(["Author 1", "Author 2"]),
@@ -110,7 +110,7 @@ describe("BooksCommandRepository", () => {
 					userId: makeUserId("user123"),
 					ISBN: makeISBN("9784123456789"),
 					title: makeBookTitle("Test Book"),
-					status: makeStatus("UNEXPORTED"),
+					status: "UNEXPORTED",
 					createdAt: makeCreatedAt(),
 				}),
 			).rejects.toThrow("Database constraint error");
@@ -144,7 +144,7 @@ describe("BooksCommandRepository", () => {
 			await booksCommandRepository.deleteById(
 				makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae"),
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.book.delete).toHaveBeenCalled();
@@ -159,7 +159,7 @@ describe("BooksCommandRepository", () => {
 				booksCommandRepository.deleteById(
 					makeId("0198bfc4-444f-71eb-8e78-46840c337877"),
 					makeUserId("user123"),
-					makeStatus("EXPORTED"),
+					"EXPORTED",
 				),
 			).rejects.toThrow("Record not found");
 
@@ -190,7 +190,7 @@ describe("BooksCommandRepository", () => {
 			await booksCommandRepository.deleteById(
 				makeId("0198bfc4-444f-71eb-8e78-4eaeec50cd3e"),
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				makeUnexportedStatus(),
 			);
 
 			expect(prisma.book.delete).toHaveBeenCalledWith({

--- a/src/infrastructures/books/repositories/books-command-repository.ts
+++ b/src/infrastructures/books/repositories/books-command-repository.ts
@@ -62,8 +62,25 @@ async function deleteById(id: Id, userId: UserId, status: Status) {
 	);
 }
 
+async function fetchBookFromGitHub(): Promise<UnexportedBook[]> {
+	const url =
+		"https://raw.githubusercontent.com/s-hirano-ist/s-public/main/src/data/book/data.gen.json";
+	try {
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch book data: ${response.statusText}`);
+		}
+		const data = await response.json();
+		return data as UnexportedBook[];
+	} catch (error) {
+		console.error("Error fetching book data:", error);
+		throw error;
+	}
+}
+
 export const booksCommandRepository: IBooksCommandRepository = {
 	create,
 	update,
 	deleteById,
+	fetchBookFromGitHub,
 };

--- a/src/infrastructures/books/repositories/books-query-repository.test.ts
+++ b/src/infrastructures/books/repositories/books-query-repository.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { makeISBN } from "@/domains/books/entities/books-entity";
-import {
-	makeStatus,
-	makeUserId,
-} from "@/domains/common/entities/common-entity";
+import { makeUserId } from "@/domains/common/entities/common-entity";
 import prisma from "@/prisma";
 import { booksQueryRepository } from "./books-query-repository";
 
@@ -90,7 +87,7 @@ describe("BooksQueryRepository", () => {
 
 			const result = await booksQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -103,7 +100,7 @@ describe("BooksQueryRepository", () => {
 
 			const result = await booksQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.book.findMany).toHaveBeenCalled();
@@ -127,7 +124,7 @@ describe("BooksQueryRepository", () => {
 
 			const result = await booksQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -141,10 +138,7 @@ describe("BooksQueryRepository", () => {
 			);
 
 			await expect(
-				booksQueryRepository.findMany(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				booksQueryRepository.findMany(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database connection error");
 
 			expect(prisma.book.findMany).toHaveBeenCalled();
@@ -157,7 +151,7 @@ describe("BooksQueryRepository", () => {
 
 			const result = await booksQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.book.count).toHaveBeenCalledWith({
@@ -171,7 +165,7 @@ describe("BooksQueryRepository", () => {
 
 			const result = await booksQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				"UNEXPORTED",
 			);
 
 			expect(prisma.book.count).toHaveBeenCalledWith({
@@ -186,10 +180,7 @@ describe("BooksQueryRepository", () => {
 			);
 
 			await expect(
-				booksQueryRepository.count(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				booksQueryRepository.count(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database count error");
 
 			expect(prisma.book.count).toHaveBeenCalledWith({

--- a/src/infrastructures/images/repositories/images-command-repository.test.ts
+++ b/src/infrastructures/images/repositories/images-command-repository.test.ts
@@ -3,7 +3,7 @@ import type { Status } from "@/domains/common/entities/common-entity";
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import {
@@ -56,7 +56,7 @@ describe("ImageCommandRepository", () => {
 				height: makePixel(600),
 				tags: [makeTag("nature"), makeTag("landscape")],
 				description: makeDescription("A beautiful landscape"),
-				status: makeStatus("UNEXPORTED"),
+				status: makeUnexportedStatus(),
 				createdAt: makeCreatedAt(),
 			});
 
@@ -85,7 +85,7 @@ describe("ImageCommandRepository", () => {
 				path: makeTestPath("image-456"),
 				userId: makeUserId("user123"),
 				contentType: makeContentType("image/jpeg"),
-				status: makeStatus("UNEXPORTED"),
+				status: makeUnexportedStatus(),
 				id: makeId("01234567-89ab-7def-8123-456789abcde1"),
 				fileSize: makeFileSize(2048),
 				width: makePixel(640),
@@ -107,7 +107,7 @@ describe("ImageCommandRepository", () => {
 					path: makeTestPath("image-123"),
 					userId: makeUserId("user123"),
 					contentType: makeContentType("image/png"),
-					status: makeStatus("UNEXPORTED"),
+					status: makeUnexportedStatus(),
 					id: makeId("01234567-89ab-7def-8123-456789abcde1"),
 					fileSize: makeFileSize(1024),
 					width: makePixel(800),
@@ -171,7 +171,7 @@ describe("ImageCommandRepository", () => {
 		test("should delete image and log success", async () => {
 			const id = makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae");
 			const userId = makeUserId("test-user-id");
-			const status = makeStatus("UNEXPORTED");
+			const status = makeUnexportedStatus();
 
 			const mockDeletedImage = {
 				path: "images/user123/image-123.png",
@@ -189,7 +189,7 @@ describe("ImageCommandRepository", () => {
 		test("should delete image with different status and log", async () => {
 			const id = makeId("0198bfc5-555f-74f9-af07-fc9c251fe2bf");
 			const userId = makeUserId("test-user-id-2");
-			const status = makeStatus("EXPORTED");
+			const status = "EXPORTED";
 
 			const mockDeletedImage = {
 				path: "images/user456/image-456.jpg",
@@ -207,7 +207,7 @@ describe("ImageCommandRepository", () => {
 		test("should handle deletion errors", async () => {
 			const id = makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae");
 			const userId = makeUserId("test-user-id");
-			const status = makeStatus("UNEXPORTED");
+			const status = makeUnexportedStatus();
 
 			vi.mocked(prisma.image.delete).mockRejectedValue(
 				new Error("Image not found"),

--- a/src/infrastructures/images/repositories/images-command-repository.ts
+++ b/src/infrastructures/images/repositories/images-command-repository.ts
@@ -1,7 +1,11 @@
-import type { Status } from "@/domains/common/entities/common-entity";
-import type { Image, Path } from "@/domains/images/entities/image-entity";
+import type { Status, UserId } from "@/domains/common/entities/common-entity";
+import type {
+	Path,
+	UnexportedImage,
+} from "@/domains/images/entities/image-entity";
 import { ImageCreatedEvent } from "@/domains/images/events/image-created-event";
 import { ImageDeletedEvent } from "@/domains/images/events/image-deleted-event";
+import { ImageUpdatedEvent } from "@/domains/images/events/image-updated-event";
 import type { IImagesCommandRepository } from "@/domains/images/repositories/images-command-repository.interface";
 import { env } from "@/env";
 import { eventDispatcher } from "@/infrastructures/events/event-dispatcher";
@@ -12,13 +16,32 @@ import { ORIGINAL_IMAGE_PATH, THUMBNAIL_IMAGE_PATH } from "./common";
 
 initializeEventHandlers();
 
-async function create(data: Image): Promise<void> {
-	const response = await prisma.image.create({ data });
+async function create(data: UnexportedImage): Promise<void> {
+	const response = await prisma.image.create({
+		data,
+		select: { id: true, userId: true, path: true },
+	});
 	await eventDispatcher.dispatch(
 		new ImageCreatedEvent({
 			id: response.id,
 			userId: response.userId,
 			caller: "addImage",
+		}),
+	);
+}
+
+async function update(path: Path, userId: UserId, data: UnexportedImage) {
+	const response = await prisma.image.update({
+		where: { path_userId: { path, userId } },
+		data,
+		select: { id: true, userId: true, path: true },
+	});
+	await eventDispatcher.dispatch(
+		new ImageUpdatedEvent({
+			id: response.id,
+			path: response.path,
+			userId: response.userId,
+			caller: "updateImage",
 		}),
 	);
 }
@@ -52,6 +75,7 @@ async function deleteById(
 
 export const imagesCommandRepository: IImagesCommandRepository = {
 	create,
+	update,
 	uploadToStorage,
 	deleteById,
 };

--- a/src/infrastructures/images/repositories/images-query-repository.test.ts
+++ b/src/infrastructures/images/repositories/images-query-repository.test.ts
@@ -1,9 +1,6 @@
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import {
-	makeStatus,
-	makeUserId,
-} from "@/domains/common/entities/common-entity";
+import { makeUserId } from "@/domains/common/entities/common-entity";
 import { Path } from "@/domains/images/entities/image-entity";
 import { minioClient } from "@/minio";
 import prisma from "@/prisma";
@@ -35,7 +32,7 @@ describe("ImagesQueryRepository", () => {
 
 			const result = await imagesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -48,7 +45,7 @@ describe("ImagesQueryRepository", () => {
 
 			const result = await imagesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.image.findMany).toHaveBeenCalled();
@@ -66,7 +63,7 @@ describe("ImagesQueryRepository", () => {
 
 			const result = await imagesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -80,10 +77,7 @@ describe("ImagesQueryRepository", () => {
 			);
 
 			await expect(
-				imagesQueryRepository.findMany(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				imagesQueryRepository.findMany(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database connection error");
 
 			expect(prisma.image.findMany).toHaveBeenCalled();
@@ -96,7 +90,7 @@ describe("ImagesQueryRepository", () => {
 
 			const result = await imagesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.image.count).toHaveBeenCalledWith({
@@ -110,7 +104,7 @@ describe("ImagesQueryRepository", () => {
 
 			const result = await imagesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				"UNEXPORTED",
 			);
 
 			expect(prisma.image.count).toHaveBeenCalledWith({
@@ -125,10 +119,7 @@ describe("ImagesQueryRepository", () => {
 			);
 
 			await expect(
-				imagesQueryRepository.count(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				imagesQueryRepository.count(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database count error");
 
 			expect(prisma.image.count).toHaveBeenCalledWith({

--- a/src/infrastructures/images/repositories/images-query-repository.ts
+++ b/src/infrastructures/images/repositories/images-query-repository.ts
@@ -6,10 +6,31 @@ import { minioClient } from "@/minio";
 import prisma from "@/prisma";
 import { ORIGINAL_IMAGE_PATH, THUMBNAIL_IMAGE_PATH } from "./common";
 
-async function findByPath(path: string, userId: string): Promise<{} | null> {
+async function findByPath(
+	path: string,
+	userId: string,
+): Promise<{
+	id: string;
+	path: string;
+	contentType: string;
+	fileSize: number | null;
+	width: number | null;
+	height: number | null;
+	tags: string[];
+	description: string | null;
+} | null> {
 	const data = await prisma.image.findUnique({
 		where: { path_userId: { path, userId } },
-		select: {},
+		select: {
+			id: true,
+			path: true,
+			contentType: true,
+			fileSize: true,
+			width: true,
+			height: true,
+			tags: true,
+			description: true,
+		},
 	});
 	return data;
 }

--- a/src/infrastructures/images/repositories/images-query-repository.ts
+++ b/src/infrastructures/images/repositories/images-query-repository.ts
@@ -70,9 +70,18 @@ async function getFromStorage(
 	return data;
 }
 
+async function getFromStorageOrThrow(
+	path: string,
+	isThumbnail: boolean,
+): Promise<void> {
+	const objKey = `${isThumbnail ? THUMBNAIL_IMAGE_PATH : ORIGINAL_IMAGE_PATH}/${path}`;
+	await minioClient.statObject(env.MINIO_BUCKET_NAME, objKey);
+}
+
 export const imagesQueryRepository: IImagesQueryRepository = {
 	findByPath,
 	findMany,
 	count,
 	getFromStorage,
+	getFromStorageOrThrow,
 };

--- a/src/infrastructures/notes/repositories/notes-command-repository.test.ts
+++ b/src/infrastructures/notes/repositories/notes-command-repository.test.ts
@@ -3,7 +3,7 @@ import type { Status } from "@/domains/common/entities/common-entity";
 import {
 	makeCreatedAt,
 	makeId,
-	makeStatus,
+	makeUnexportedStatus,
 	makeUserId,
 } from "@/domains/common/entities/common-entity";
 import {
@@ -38,7 +38,7 @@ describe("NotesCommandRepository", () => {
 				markdown: makeMarkdown("# Test Note\n\nThis is test markdown note."),
 				userId: makeUserId("user123"),
 				id: makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae"),
-				status: makeStatus("UNEXPORTED"),
+				status: makeUnexportedStatus(),
 				createdAt: makeCreatedAt(),
 			});
 
@@ -57,7 +57,7 @@ describe("NotesCommandRepository", () => {
 					markdown: makeMarkdown("# Test Note\n\nThis is test markdown note."),
 					userId: makeUserId("user123"),
 					id: makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae"),
-					status: makeStatus("EXPORTED"),
+					status: makeUnexportedStatus(),
 					createdAt: makeCreatedAt(),
 				}),
 			).rejects.toThrow("Database constraint error");
@@ -70,7 +70,7 @@ describe("NotesCommandRepository", () => {
 		test("should delete note and log success", async () => {
 			const id = makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae");
 			const userId = makeUserId("test-user-id");
-			const status = makeStatus("UNEXPORTED");
+			const status = "UNEXPORTED";
 
 			const mockDeletedNote = {
 				title: "Deleted Note",
@@ -86,7 +86,7 @@ describe("NotesCommandRepository", () => {
 		test("should delete note with different status", async () => {
 			const id = makeId("0198bfc5-555f-74f9-af07-fc9c251fe2bf");
 			const userId = makeUserId("test-user-id-2");
-			const status = makeStatus("EXPORTED");
+			const status = "EXPORTED";
 
 			const mockDeletedNote = {
 				title: "Another Note",
@@ -102,7 +102,7 @@ describe("NotesCommandRepository", () => {
 		test("should handle deletion errors", async () => {
 			const id = makeId("0198bfc4-444e-73e8-9ef6-eb9b250ed1ae");
 			const userId = makeUserId("test-user-id");
-			const status = makeStatus("UNEXPORTED");
+			const status = "UNEXPORTED";
 
 			vi.mocked(prisma.note.delete).mockRejectedValue(
 				new Error("Note not found"),

--- a/src/infrastructures/notes/repositories/notes-query-repository.test.ts
+++ b/src/infrastructures/notes/repositories/notes-query-repository.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import {
-	makeStatus,
-	makeUserId,
-} from "@/domains/common/entities/common-entity";
+import { makeUserId } from "@/domains/common/entities/common-entity";
 import { makeNoteTitle } from "@/domains/notes/entities/note-entity";
 import prisma from "@/prisma";
 import { notesQueryRepository } from "./notes-query-repository";
@@ -89,7 +86,7 @@ describe("NotesQueryRepository", () => {
 
 			const result = await notesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -106,7 +103,7 @@ describe("NotesQueryRepository", () => {
 
 			const result = await notesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				{},
 			);
 
@@ -128,7 +125,7 @@ describe("NotesQueryRepository", () => {
 
 			const result = await notesQueryRepository.findMany(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 				params,
 			);
 
@@ -146,11 +143,7 @@ describe("NotesQueryRepository", () => {
 			);
 
 			await expect(
-				notesQueryRepository.findMany(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-					{},
-				),
+				notesQueryRepository.findMany(makeUserId("user123"), "EXPORTED", {}),
 			).rejects.toThrow("Database connection error");
 
 			expect(prisma.note.findMany).toHaveBeenCalledWith({
@@ -166,7 +159,7 @@ describe("NotesQueryRepository", () => {
 
 			const result = await notesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("EXPORTED"),
+				"EXPORTED",
 			);
 
 			expect(prisma.note.count).toHaveBeenCalledWith({
@@ -180,7 +173,7 @@ describe("NotesQueryRepository", () => {
 
 			const result = await notesQueryRepository.count(
 				makeUserId("user123"),
-				makeStatus("UNEXPORTED"),
+				"UNEXPORTED",
 			);
 
 			expect(prisma.note.count).toHaveBeenCalledWith({
@@ -195,10 +188,7 @@ describe("NotesQueryRepository", () => {
 			);
 
 			await expect(
-				notesQueryRepository.count(
-					makeUserId("user123"),
-					makeStatus("EXPORTED"),
-				),
+				notesQueryRepository.count(makeUserId("user123"), "EXPORTED"),
 			).rejects.toThrow("Database count error");
 
 			expect(prisma.note.count).toHaveBeenCalledWith({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 記事/ノート/書籍/画像で公開状態をUNEXPORTED/EXPORTEDの二段階モデルに変更し、create/update/export APIを導入。
  * OgImageUrlを含むOGメタデータ拡張、サムネ生成API名変更（makeThumbnailBufferFromFile）。
  * ドメインサービスにchangeXStatus系（NEED_CREATE/NEED_UPDATE/NO_UPDATE）とImagesDomainServiceを追加。
  * ドメインイベント（Book/Article/Note/ImageUpdatedEvent）を追加。

* **雑務**
  * データ同期スクリプト追加（images/original, images/thumbnail パス公開）。
  * 各コマンドリポジトリに update を追加・公開API拡張。

* **テスト**
  * ステータスAPI名変更に伴うテスト修正（makeUnexportedStatus / 文字列化）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->