### PR TITLE
chore: add minimum release age

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,7 @@
         'dockerfile',
       ],
       allowedVersions: '/^[0-9]*[02468]([.-].*)?$/',
+      "minimumReleaseAge": '3 days',
     },
     {
       matchManagers: [
@@ -61,6 +62,7 @@
         'peerDependencies',
       ],
       groupName: 'patch',
+      "minimumReleaseAge": '3 days',
     },
     {
       matchManagers: [
@@ -78,6 +80,7 @@
         'peerDependencies',
       ],
       groupName: 'minor',
+      "minimumReleaseAge": '3 days',
     },
     {
       matchManagers: [
@@ -85,6 +88,7 @@
       ],
       groupName: 'GitHub Actions',
       groupSlug: 'github-actions',
+      "minimumReleaseAge": '3 days',
     },
   ],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 依存関係およびGitHub Actionsの自動アップデートに「リリースから3日待機」を導入し、直後の不具合リスクを低減して安定性を向上。
  - npmのパッチ/マイナー更新、DockerベースのNodeイメージ更新、GitHub Actions更新に適用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->