### PR TITLE
fix: READMEのビルドステータスバッジを修正（cd.yaml→ci.yaml）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # s-private
 
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)
-![CI/CD status](https://img.shields.io/github/actions/workflow/status/s-hirano-ist/s-private/cd.yaml?branch=main)
+![CI status](https://img.shields.io/github/actions/workflow/status/s-hirano-ist/s-private/ci.yaml?branch=main)
 ![GitHub stars](https://img.shields.io/github/stars/s-hirano-ist/s-private.svg)
 
 ## Live Services


### PR DESCRIPTION
cd.yamlは存在しないワークフローを参照していたため、
実際のCIワークフローであるci.yamlに修正。

https://claude.ai/code/session_01K2BoaXhe85FdwiHdHSdfg6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* README.mdのCI/CDバッジをCIステータスバッジに変更し、対応するワークフロー参照パスとバッジラベルテキストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->