### PR TITLE
fix: file type to add webp

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
 	"css": {
 		"parser": {
 			"cssModules": true,

--- a/packages/core/shared-kernel/entities/file-entity.test.ts
+++ b/packages/core/shared-kernel/entities/file-entity.test.ts
@@ -63,8 +63,12 @@ describe("file-entity", () => {
 			expect(makeContentType("png")).toBe("png");
 		});
 
-		test("should throw error for unsupported content type", () => {
-			expect(() => makeContentType("image/webp")).toThrow(ZodError);
+		test("should accept image/webp", () => {
+			expect(makeContentType("image/webp")).toBe("image/webp");
+		});
+
+		test("should accept webp", () => {
+			expect(makeContentType("webp")).toBe("webp");
 		});
 
 		test("should throw error for empty string", () => {

--- a/packages/core/shared-kernel/entities/file-entity.ts
+++ b/packages/core/shared-kernel/entities/file-entity.ts
@@ -69,7 +69,15 @@ export const makePath = (v: string, sanitizeAndUnique: boolean): Path => {
  * @see {@link makeContentType} for factory function
  */
 export const ContentType = z
-	.enum(["image/jpeg", "image/png", "image/gif", "image/webp", "jpeg", "png", "webp"])
+	.enum([
+		"image/jpeg",
+		"image/png",
+		"image/gif",
+		"image/webp",
+		"jpeg",
+		"png",
+		"webp",
+	])
 	.brand<"ContentType">();
 
 /**

--- a/packages/core/shared-kernel/entities/file-entity.ts
+++ b/packages/core/shared-kernel/entities/file-entity.ts
@@ -59,7 +59,7 @@ export const makePath = (v: string, sanitizeAndUnique: boolean): Path => {
  * Zod schema for validating file content types.
  *
  * @remarks
- * Only allows JPEG, PNG, and GIF formats.
+ * Only allows JPEG, PNG, GIF, and WebP formats.
  *
  * @example
  * ```typescript
@@ -69,7 +69,7 @@ export const makePath = (v: string, sanitizeAndUnique: boolean): Path => {
  * @see {@link makeContentType} for factory function
  */
 export const ContentType = z
-	.enum(["image/jpeg", "image/png", "image/gif", "jpeg", "png"])
+	.enum(["image/jpeg", "image/png", "image/gif", "image/webp", "jpeg", "png", "webp"])
 	.brand<"ContentType">();
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * WebP画像形式がコンテンツタイプとしてサポートされるようになりました。`image/webp` および `webp` フォーマットが受け入れられるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->