### PR TITLE
feat(scripts): add s-content-format bin backed by dprint

### DIFF
--- a/packages/scripts/configs/dprint.json
+++ b/packages/scripts/configs/dprint.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://dprint.dev/schemas/v0.json",
+	"lineWidth": 80,
+	"indentWidth": 2,
+	"useTabs": false,
+	"markdown": {
+		"lineWidth": 80,
+		"textWrap": "maintain"
+	},
+	"json": {
+		"indentWidth": 2
+	},
+	"yaml": {
+		"indentWidth": 2,
+		"quotes": "preferDouble"
+	},
+	"plugins": [
+		"https://plugins.dprint.dev/markdown-0.21.1.wasm",
+		"https://plugins.dprint.dev/json-0.21.3.wasm",
+		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
+	]
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,6 +4,7 @@
 	"description": "CLI scripts for s-private data operations",
 	"type": "module",
 	"bin": {
+		"s-content-format": "./dist/s-content-format.js",
 		"fetch-articles": "./dist/fetch-articles.js",
 		"fetch-books": "./dist/fetch-books.js",
 		"fetch-images": "./dist/fetch-images.js",
@@ -36,6 +37,7 @@
 		"clean": "rm -rf dist",
 		"typecheck": "tsc --noEmit",
 		"prepublishOnly": "pnpm run build",
+		"s-content-format": "tsx src/s-content-format.ts",
 		"fetch-articles": "tsx src/fetch-articles.ts",
 		"fetch-books": "tsx src/fetch-books.ts",
 		"fetch-images": "tsx src/fetch-images.ts",
@@ -65,6 +67,7 @@
 	},
 	"files": [
 		"dist",
+		"configs",
 		"README.md",
 		"LICENSE"
 	],
@@ -84,6 +87,7 @@
 		"@s-hirano-ist/s-search": "workspace:*",
 		"@s-hirano-ist/s-storage": "workspace:*",
 		"cheerio": "1.2.0",
+		"dprint": "0.54.0",
 		"glob": "13.0.6",
 		"iconv-lite": "0.7.2",
 		"sharp": "0.34.5",

--- a/packages/scripts/src/s-content-format.ts
+++ b/packages/scripts/src/s-content-format.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const dprintPkgPath = require.resolve("dprint/package.json");
+const dprintBin = path.join(path.dirname(dprintPkgPath), "bin.cjs");
+
+const packageRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+const configPath = path.join(packageRoot, "configs", "dprint.json");
+
+const DEFAULT_EXCLUDES = [
+	"!**/node_modules",
+	"!**/dist",
+	"!**/build",
+	"!**/coverage",
+	"!**/raw/article/**",
+	"!**/bun.lock",
+	"!**/package-lock.json",
+	"!**/yarn.lock",
+	"!**/.env",
+	"!**/.env.*",
+];
+
+const rawArgs = process.argv.slice(2);
+const checkFlagIndex = rawArgs.indexOf("--check");
+const isCheck = checkFlagIndex !== -1;
+const remaining =
+	checkFlagIndex === -1
+		? rawArgs
+		: [
+				...rawArgs.slice(0, checkFlagIndex),
+				...rawArgs.slice(checkFlagIndex + 1),
+			];
+const subcommand = isCheck ? "check" : "fmt";
+
+const hasPositional = remaining.some((arg) => !arg.startsWith("-"));
+const finalArgs = hasPositional
+	? remaining
+	: [...remaining, ".", ...DEFAULT_EXCLUDES];
+
+const child = spawn(
+	process.execPath,
+	[dprintBin, subcommand, "--config", configPath, ...finalArgs],
+	{ stdio: "inherit" },
+);
+
+child.on("exit", (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+	process.exit(code ?? 1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
+      dprint:
+        specifier: 0.54.0
+        version: 0.54.0
       glob:
         specifier: 13.0.6
         version: 13.0.6
@@ -756,6 +759,68 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@dprint/darwin-arm64@0.54.0':
+    resolution: {integrity: sha512-yqRI4enH+BDp+4+ZsPVdZM5h873JK1lN7li9l9A5u4C4cvh1oEsiBWAzEPccRkJ2ctF8LgaizBSxO38sqEVYbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@dprint/darwin-x64@0.54.0':
+    resolution: {integrity: sha512-W9BARpgHypcQwatg5mnHaCpX6pLX5dBxxiv+tZKruhOmq8MKYOrAYDXlceMuHSowmWREfUF5yL4SRgXDGI6WQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@dprint/linux-arm64-glibc@0.54.0':
+    resolution: {integrity: sha512-VhM7p70VFuNqxZMdiv1e+nMboPj/hMFlTIBWrRaX7+6VThs9mJr9+94wrUeXgfnfsyaEKSbRFa/dru1PINoSNw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@dprint/linux-arm64-musl@0.54.0':
+    resolution: {integrity: sha512-QS1A74Lv60/L9oemHCzbHgOLbV2smSJG5IxS5fjf8ZWetyUt918WDzIHBilz/+uiB+OlW2UVTsm952UG0YOrLw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@dprint/linux-loong64-glibc@0.54.0':
+    resolution: {integrity: sha512-8Myka2/0KbhuZnEKL6jagPXTgDKVpd/tfXDRa0oibUBgaqOSku6iRMzHGa/PhqHL+s14Gcp+/cIHz0zU3Tkgug==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@dprint/linux-loong64-musl@0.54.0':
+    resolution: {integrity: sha512-/AN3xCuMhC4PK7Pbj7/4zBuhFGr4m0OHV/5uGTfzpkKX/3+AXoyKl7PbT2VlNMGXAK0kuRThfjtx23gIwlWk7Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@dprint/linux-riscv64-glibc@0.54.0':
+    resolution: {integrity: sha512-Aw2vXzzwFDpPbXh6ajsSabVCkCc66C3hCyMKprR/IxYvFtjYX80nh1ox0c7iaw6c4HacHMRLGw7FUSXvomPaEQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@dprint/linux-x64-glibc@0.54.0':
+    resolution: {integrity: sha512-zZqj3wQELOX8n6QfT2uuWoMf64Wv0lMXNyam3btm+PKkg0P6a54TPL09Bs9XsViOdxgTcamsiQ7HlErt/LEjIA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@dprint/linux-x64-musl@0.54.0':
+    resolution: {integrity: sha512-it6Qdt06dyW2adbAXpOCb7/KQLxlm4i1UphUAWqWsZk4t3EYetyAza9J0g3Vu9itIWSEIo9MnccgANckQJ6+qw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@dprint/win32-arm64@0.54.0':
+    resolution: {integrity: sha512-F5kjV/6I9YtNOTDWHUpTqM2HHHS510BPL7z4NJuU0nDnaVeks7GwNEltGr56CcsG8XQYhkiAsqZytPu6AhA2hQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@dprint/win32-x64@0.54.0':
+    resolution: {integrity: sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg==}
+    cpu: [x64]
+    os: [win32]
 
   '@edge-runtime/format@2.2.1':
     resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
@@ -5218,6 +5283,10 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dprint@0.54.0:
+    resolution: {integrity: sha512-sIy25poR2gRP/tWPTgP0MPeJoJcpv0xzYDcsboapvthbEt1Qw3Al252CA0xFyIh2cYEGGKyBJtKokryv4ERlJw==}
+    hasBin: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -9479,6 +9548,39 @@ snapshots:
       - '@chromatic-com/playwright'
 
   '@colors/colors@1.5.0':
+    optional: true
+
+  '@dprint/darwin-arm64@0.54.0':
+    optional: true
+
+  '@dprint/darwin-x64@0.54.0':
+    optional: true
+
+  '@dprint/linux-arm64-glibc@0.54.0':
+    optional: true
+
+  '@dprint/linux-arm64-musl@0.54.0':
+    optional: true
+
+  '@dprint/linux-loong64-glibc@0.54.0':
+    optional: true
+
+  '@dprint/linux-loong64-musl@0.54.0':
+    optional: true
+
+  '@dprint/linux-riscv64-glibc@0.54.0':
+    optional: true
+
+  '@dprint/linux-x64-glibc@0.54.0':
+    optional: true
+
+  '@dprint/linux-x64-musl@0.54.0':
+    optional: true
+
+  '@dprint/win32-arm64@0.54.0':
+    optional: true
+
+  '@dprint/win32-x64@0.54.0':
     optional: true
 
   '@edge-runtime/format@2.2.1': {}
@@ -14005,6 +14107,20 @@ snapshots:
   dotenv@16.0.3: {}
 
   dotenv@16.6.1: {}
+
+  dprint@0.54.0:
+    optionalDependencies:
+      '@dprint/darwin-arm64': 0.54.0
+      '@dprint/darwin-x64': 0.54.0
+      '@dprint/linux-arm64-glibc': 0.54.0
+      '@dprint/linux-arm64-musl': 0.54.0
+      '@dprint/linux-loong64-glibc': 0.54.0
+      '@dprint/linux-loong64-musl': 0.54.0
+      '@dprint/linux-riscv64-glibc': 0.54.0
+      '@dprint/linux-x64-glibc': 0.54.0
+      '@dprint/linux-x64-musl': 0.54.0
+      '@dprint/win32-arm64': 0.54.0
+      '@dprint/win32-x64': 0.54.0
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ onlyBuiltDependencies:
   - '@prisma/engines'
   - '@sentry/cli'
   - '@swc/core'
+  - dprint
   - esbuild
   - memlab
   - prisma


### PR DESCRIPTION
## Summary

- `@s-hirano-ist/s-scripts` に dprint ベースの `s-content-format` bin を追加
- markdown / json / yaml のプラグインと dprint 設定をパッケージ内に同梱 (`packages/scripts/configs/dprint.json`)
- `--check` フラグで check モード、引数なしで `.` + デフォルト excludes (node_modules / dist / raw/article / lock files / .env) にフォールバック

## Motivation

`../s-contents` は現状 Prettier + markdownlint-cli2 + textlint の 3 本立てで formatter/linter を管理しており、それぞれ独立した devDependencies と Renovate 管理対象になっている。s-contents は既に `@s-hirano-ist/s-scripts` を強く利用しているため、formatter/linter を s-scripts 側に同梱してしまえば、**s-contents の package update 対象を `@s-hirano-ist/s-scripts` 1 本に絞れる**。

あわせて以下を整理:
- **Prettier → dprint へ乗り換え** (Rust バイナリ + WASM プラグインで高速・軽量)
- **markdownlint-cli2 廃止** (現設定ではルールの大半が既に無効化済で、実効ルールは dprint の markdown 整形で代替可能)
- **textlint 廃止**

## Changes

- `packages/scripts/src/s-content-format.ts` (new) — dprint を `--config` 指定で spawn するラッパー
- `packages/scripts/configs/dprint.json` (new) — markdown 0.21.1 / json 0.21.3 / pretty_yaml v0.6.0、lineWidth 80 / indent 2 spaces / markdown は `textWrap: "maintain"` (日本語改行保護)
- `packages/scripts/package.json` — `dprint 0.54.0` 追加、`s-content-format` を bin / scripts に登録、`configs` を files に追加
- `pnpm-workspace.yaml` — `onlyBuiltDependencies` に `dprint` を追加 (postinstall でバイナリ取得)

## Verification

- [x] `pnpm --filter @s-hirano-ist/s-scripts typecheck` 通過
- [x] `pnpm --filter @s-hirano-ist/s-scripts build` 通過
- [x] ローカルで md / json / yaml それぞれの整形動作・`--check` モード・idempotency を確認
- [ ] publish 後に s-contents 側で `bun install` → `bun format:fix` → `bun format:check` が green になることを確認

## Test plan

- [ ] PR マージ → release-please が `1.21.0` の release PR を生成
- [ ] release PR マージで npm へ publish
- [ ] s-contents の追従 PR (別リポジトリ) をマージして CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)