### PR TITLE
fix(ci): add CF Access credentials to memlab workflow

### DIFF
--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -47,6 +47,8 @@ jobs:
           MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_COLLECTION_NAME: ${{ secrets.QDRANT_COLLECTION_NAME }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
@@ -67,6 +69,8 @@ jobs:
           MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_COLLECTION_NAME: ${{ secrets.QDRANT_COLLECTION_NAME }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}


### PR DESCRIPTION
MinIO等のCloudflare Tunnel経由アクセスに必要な
CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRETがmemlabワークフローで
未設定のためビルド・起動が失敗していた。CIワークフローと同様に
build/startの両ステップに追加する。

https://claude.ai/code/session_01WJgfHh4QGFBGV7LXjwTa1u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores（その他の変更）**
  * ビルドワークフロー設定を更新しました。アプリケーションのビルド処理とサーバー起動プロセスの環境構成を拡張し、必要な認証設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->