### PR TITLE
fix(ci): bypass doppler in CI for app start script

### DIFF
--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -54,7 +54,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
 
       - name: Start server
-        run: pnpm --filter s-private-app start &
+        run: pnpm --filter s-private-app start > server.log 2>&1 &
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
@@ -86,6 +86,8 @@ jobs:
             sleep 2
           done
           echo "Server failed to start"
+          echo "--- server.log ---"
+          cat server.log || true
           exit 1
 
       - name: Run memlab scenarios

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
 		"dev": "doppler run -- next dev",
 		"build": "if [ -n \"$CI\" ]; then next build; else doppler run -- next build; fi",
 		"analyze": "doppler run -- next experimental-analyze",
-		"start": "doppler run -- next start",
+		"start": "if [ -n \"$CI\" ]; then next start; else doppler run -- next start; fi",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {


### PR DESCRIPTION
The memlab workflow's "Wait for server" step was timing out because
`pnpm start` invokes `doppler run -- next start`, but doppler isn't
installed on the GitHub Actions runner. The background server failed
silently, leaving health checks to time out with no diagnostic output.

- Mirror the build script's CI-bypass pattern in start so `next start`
  runs directly when $CI is set (env vars are already injected by the
  workflow).
- Capture the background server's stdout/stderr to server.log and dump
  it on health-check timeout so future startup failures are visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* CI/CD ワークフローとサーバー起動プロセスの改善
* ビルド環境に応じた起動メカニズムの最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->