### PR TITLE
fix(ci): install Chrome for Puppeteer before running memlab

### DIFF
--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -31,6 +31,9 @@ jobs:
 
       - run: pnpm i --frozen-lockfile
 
+      - name: Install Chrome for Puppeteer
+        run: pnpm dlx puppeteer browsers install chrome
+
       - name: Build application
         run: pnpm build
         env:


### PR DESCRIPTION
memlab uses Puppeteer internally which requires a Chrome binary.
The GitHub Actions runner doesn't ship with the exact Chrome version
Puppeteer expects, so install it explicitly via `puppeteer browsers
install chrome`.