### PR TITLE
fix(ci): pin puppeteer version when installing Chrome for memlab

### DIFF
--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm i --frozen-lockfile
 
       - name: Install Chrome for Puppeteer
-        run: pnpm dlx puppeteer browsers install chrome
+        run: pnpm dlx puppeteer@24.40.0 browsers install chrome
 
       - name: Build application
         run: pnpm build


### PR DESCRIPTION
`pnpm dlx puppeteer` resolves to the latest puppeteer, which installs a Chrome version that doesn't match what memlab's bundled puppeteer@24.40.0 requires (146.0.7680.153). Pin the version so the correct Chrome build is placed in /home/runner/.cache/puppeteer.