### PR TITLE
DRAFT: fix(memlab): authenticate via Auth0 and use correct route paths

### DIFF
--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -95,6 +95,9 @@ jobs:
 
       - name: Run memlab scenarios
         run: pnpm memlab:all
+        env:
+          E2E_AUTH0_USERNAME: ${{ secrets.E2E_AUTH0_USERNAME }}
+          E2E_AUTH0_PASSWORD: ${{ secrets.E2E_AUTH0_PASSWORD }}
 
       - name: Upload memlab results
         if: always()

--- a/memlab/helpers/auth.cjs
+++ b/memlab/helpers/auth.cjs
@@ -1,0 +1,42 @@
+/**
+ * Shared Auth0 login helper for memlab scenarios.
+ * Reuses the E2E_AUTH0_USERNAME / E2E_AUTH0_PASSWORD env vars used by Playwright.
+ */
+
+async function loginWithAuth0(page) {
+	const username = process.env.E2E_AUTH0_USERNAME;
+	const password = process.env.E2E_AUTH0_PASSWORD;
+
+	if (!username || !password) {
+		throw new Error(
+			"E2E_AUTH0_USERNAME and E2E_AUTH0_PASSWORD must be set for memlab scenarios",
+		);
+	}
+
+	await page.goto("http://localhost:3000/", { waitUntil: "domcontentloaded" });
+	await page.waitForFunction(() => /auth0/i.test(window.location.hostname), {
+		timeout: 30_000,
+	});
+
+	await page.waitForSelector('input[name="username"], input[type="email"]', {
+		timeout: 30_000,
+	});
+	await page.type(
+		'input[name="username"], input[type="email"]',
+		username,
+		{ delay: 10 },
+	);
+	await page.type('input[name="password"]', password, { delay: 10 });
+
+	await Promise.all([
+		page.waitForNavigation({ waitUntil: "networkidle0", timeout: 60_000 }),
+		page.click('button[type="submit"]'),
+	]);
+
+	await page.waitForFunction(
+		() => window.location.hostname === "localhost",
+		{ timeout: 30_000 },
+	);
+}
+
+module.exports = { loginWithAuth0 };

--- a/memlab/scenarios/article-list-navigation.cjs
+++ b/memlab/scenarios/article-list-navigation.cjs
@@ -2,8 +2,14 @@
  * Scenario: Navigate between article tabs (articles → notes → articles).
  * Detects IntersectionObserver leaks from useInfiniteScroll hook.
  */
+const { loginWithAuth0 } = require("../helpers/auth.cjs");
+
 module.exports = {
-	url: () => "http://localhost:3000/ja/main/articles",
+	url: () => "http://localhost:3000/ja/articles",
+
+	setup: async (page) => {
+		await loginWithAuth0(page);
+	},
 
 	action: async (page) => {
 		const notesTab = await page.waitForSelector('nav a[href*="/notes"]');

--- a/memlab/scenarios/drawer-open-close.cjs
+++ b/memlab/scenarios/drawer-open-close.cjs
@@ -2,8 +2,14 @@
  * Scenario: Open and close the SearchDrawer.
  * Detects DOM reference leaks from Drawer component lifecycle.
  */
+const { loginWithAuth0 } = require("../helpers/auth.cjs");
+
 module.exports = {
-	url: () => "http://localhost:3000/ja/main/articles",
+	url: () => "http://localhost:3000/ja/articles",
+
+	setup: async (page) => {
+		await loginWithAuth0(page);
+	},
 
 	action: async (page) => {
 		const searchButton = await page.waitForSelector(


### PR DESCRIPTION
The memlab CI scenarios were navigating to /ja/main/articles, which does
not exist — the (dumper) route group means the routes live at /ja/articles,
/ja/notes, etc. Unauthenticated requests were also redirected to Auth0's
universal login (/u/login), so waitForSelector('nav a[href*="/notes"]')
timed out after ~30s and the action step failed.

- Fix scenario URLs to /ja/articles
- Add memlab/helpers/auth.cjs that logs in via Auth0 using the same
  E2E_AUTH0_USERNAME / E2E_AUTH0_PASSWORD env vars used by Playwright
- Invoke the helper from each scenario's setup() hook so the nav is
  rendered before the baseline heap snapshot is taken
- Pass the E2E_AUTH0_* secrets to the memlab workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストワークフローの認証機構を強化し、メモリリーク検査シナリオに認証ステップを追加しました。
  * テスト環境の安定性向上のため、シナリオの初期URLを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->