### PR TITLE
chore(ci): normalize MH4GF action version comment for renovate

### DIFF
--- a/.github/workflows/depcruise.yaml
+++ b/.github/workflows/depcruise.yaml
@@ -15,6 +15,6 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: MH4GF/dependency-cruiser-report-action@885013e37581e3472385ffa93c821b3505336bc1 #v2
+      - uses: MH4GF/dependency-cruiser-report-action@885013e37581e3472385ffa93c821b3505336bc1 # v2.5.3
         with:
           package-manager: pnpm


### PR DESCRIPTION
## Summary

- `.github/workflows/depcruise.yaml` の `MH4GF/dependency-cruiser-report-action` のバージョンコメントを `#v2` → `# v2.5.3` に修正
- これにより Renovate の `Could not determine new digest for update (github-tags package MH4GF/dependency-cruiser-report-action)` 警告を解消

## 根本原因

Renovate はコメントを「現在のタグ名」として解釈し digest を解決するが、上流の `MH4GF/dependency-cruiser-report-action` は floating major tag (`v2`) を提供しておらず、`v2.0.0` … `v2.5.3` の patch 単位タグのみ。コメント `#v2` が実在タグと一致せず lookup に失敗していた。digest `885013e3...` は `v2.5.3` と一致しているため、コメントだけ正しい実在タグに揃えれば解決する。

`actions/checkout@... # v6` が動くのは、向こうが major floating tag `v6` を維持しているため。

## Test plan

- [ ] `depcruise` ジョブが PR 上で完走することを確認（コメント変更のみなので動作影響なし）
- [ ] main マージ後、Renovate Dependency Dashboard から当該 lookup warning が消えることを確認
- [ ] 後続の Renovate スケジュール実行で `MH4GF/dependency-cruiser-report-action` の更新 PR が出せる状態になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)