### PR TITLE
fix(deps): sync pnpm-lock.yaml with overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,11 @@ overrides:
   minimatch@>=10.0.0 <10.2.1: 10.2.5
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  hono@<4.12.4: 4.12.16
+  hono@<4.12.4: 4.12.17
   '@hono/node-server@<1.19.10': 2.0.1
   effect@>=3.0.0 <3.20.0: 3.21.2
   undici@<6.21.1: 8.1.0
+  semver@<7: ^7.7.4
   vite: ^7.3.1
 
 importers:
@@ -163,8 +164,8 @@ importers:
         specifier: 8.59.0
         version: 8.59.0(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       vercel:
-        specifier: 52.0.0
-        version: 52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
+        specifier: 53.2.0
+        version: 53.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
@@ -1283,7 +1284,7 @@ packages:
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.16
+      hono: 4.12.17
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4144,8 +4145,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/backends@0.2.0':
-    resolution: {integrity: sha512-7J0nJCd7h29CXG0jeejS8DnI4qAF96Fo6qibAPG7nbbJ5v0ZpWZhzeL8XwvvT3du6S50bRGcQCPJQNcShw6pEQ==}
+  '@vercel/backends@0.3.0':
+    resolution: {integrity: sha512-mhTPAeX6w2zS7GvANq+Ox2qHExFevDK8BIkAnJIIhYgrey7kFlZTM04AZjZYctybsvyInPyPYUwgpmVWNotTGg==}
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
@@ -4153,11 +4154,11 @@ packages:
     resolution: {integrity: sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.20.0':
-    resolution: {integrity: sha512-Jd29k42KSCRKOs+oSSVthw4xSjZBK3pUDG6AZl95/TsvIDNwRkjI2Nvs1ZcYDJdeLR346PQdWReFJGqkf/tb6A==}
+  '@vercel/build-utils@13.21.0':
+    resolution: {integrity: sha512-A1vtlzFYbjvxRxhnt94LUxrn9JVX2EuXALi/NFyxNA1M51eGQwI5LZaroNlgIRXdx7LCJxBQEUMKc1fi0aqU/g==}
 
-  '@vercel/cervel@0.0.55':
-    resolution: {integrity: sha512-uRisWx/d5goDEKx9eVpDjT4LA65FsOmDRw65ZMqkFZJbeX496ss37g1+/yiVBrQ0+35RcTYB9K1i8JAMFqv57w==}
+  '@vercel/cervel@0.1.0':
+    resolution: {integrity: sha512-YFihXM6jTNzCsX3t9thDbQxjHtQvYzN5lbv/Q+pwMNFwWrMqeFMdshXzM0qm1UH7lnW6OUQ4cNbc6xQU6JTuVQ==}
     hasBin: true
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
@@ -4166,17 +4167,17 @@ packages:
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.71':
-    resolution: {integrity: sha512-YTEIX6hfpgg71D/45QyYGLj/wXUjnvfbbNWOgbnmWs9B2yWeZzWFysp6umVg99bvvyxgaPfes9I0MQbqNMvIgA==}
+  '@vercel/elysia@0.1.73':
+    resolution: {integrity: sha512-TSPiGgIYW1lwR2Rjjbf86dTAxepweu1+5sei/EzFXiqcCpFzVElO6aETNCeimOTcrwft7//+IsaSpVBwxkyqFw==}
 
-  '@vercel/error-utils@2.0.3':
-    resolution: {integrity: sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==}
+  '@vercel/error-utils@2.1.0':
+    resolution: {integrity: sha512-DiJcXBOB9N6QM4d7hYPM9Ck/AUjzBl58XNQPxS74o7CuvIanjzrGgygP/70VsyEASeIJMazk1LrhwcNTR/eZGQ==}
 
-  '@vercel/express@0.1.81':
-    resolution: {integrity: sha512-Y7J5L7jdiJ/3ojo0SO2OVINCN4+CzST0kW9SXLCB75oNajwZ0wFsUSp/x5PqjDtJ2WU9QDIXO7qBhjrRkaEK4Q==}
+  '@vercel/express@0.1.83':
+    resolution: {integrity: sha512-nFgPKHKG/rckqy6JbOqjNyFNM6PdqFmomYnGaSliZ/a4kXxadPK4NVBrhQ0aJJvDIWv+Gx6IX99QPkKLRq47Lg==}
 
-  '@vercel/fastify@0.1.74':
-    resolution: {integrity: sha512-CjjuHKysQs41MJOWHVGXyiZvhLQBzAe5KRamXgs4Tn0lNztQh/tY0TlB8Qtty8+R2c5I4l0EnNCSxQ3a/Nayxg==}
+  '@vercel/fastify@0.1.76':
+    resolution: {integrity: sha512-rbKXsOYlW0cUuXjDkkl9az9tB3ukkFsQjZwT/E3o9IXhZsMmYPWGG1CqS65/qYCpsF9bCfXgPgDBErDxL1NrgA==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -4185,37 +4186,37 @@ packages:
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.1.21':
-    resolution: {integrity: sha512-QHsoUoiLaUBq6px9oNUtTh2M/Ba1lNa3fVvEU70gY3PkzVlEf20tS/g04lEnBhtqMCSMJgziO8/Ql058pcppFA==}
+  '@vercel/gatsby-plugin-vercel-builder@2.2.0':
+    resolution: {integrity: sha512-Qs3b6OjGsWdjCsSo6elZ96Ip7Bs0sgN5fkTMdKGzH/IOpX+UOXiuu3uOIjvLDMAf2zOZHwlBGYMNKXF5WW/NvQ==}
 
-  '@vercel/go@3.5.0':
-    resolution: {integrity: sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==}
+  '@vercel/go@3.6.0':
+    resolution: {integrity: sha512-60gQxuQBfuGQCPdp1zmG3bfWncj+MRDm9KNogKeu4cA1uC2kGwUoCI6vr8kpGTv62v3gwSLbcnJ3RsqOqxb3KA==}
 
-  '@vercel/h3@0.1.80':
-    resolution: {integrity: sha512-Vu+l1qXjD9P8P5rnLKGRaSbKkbBnxc2in+zHN7tD0vWxLcpecrPKnAgbVozT37LDvpT5I38aXQIFMKokjCQfAw==}
+  '@vercel/h3@0.1.82':
+    resolution: {integrity: sha512-tiLO/+EcrWYFYT3OvF/gI63Arc60w5m3zPU4dMrTuHnm0DW418oPFVvtKdN/B2FOGN+KEeUrfl8uXz1AdyTSog==}
 
-  '@vercel/hono@0.2.74':
-    resolution: {integrity: sha512-NWOEeb3Vg8d9Y5/wnjajdPzXrrImGoSds/PkqQK802mzR9/8svdFhe1qnqSxzM6e3Y2iID0DJxhnZjVjowkOcQ==}
+  '@vercel/hono@0.2.76':
+    resolution: {integrity: sha512-gveEPPtgMHVl0Q9GPQw7FSLslBGJ8EidF56vsDyCtLIsfyIXnEiMXT9fwQ3u2fH7nc7FRk0hjFiqlhY1km8Xwg==}
 
-  '@vercel/hydrogen@1.3.6':
-    resolution: {integrity: sha512-Ec8dKEjGIM4BfThcRLtQs5zaJ4+iJbgLZwkytwi7Blk8VrK6W2F1dtLDmVQYZdVnQcnmHmTx8mxUuMkfP06Mnw==}
+  '@vercel/hydrogen@1.3.7':
+    resolution: {integrity: sha512-nh8hZ76Ipf9FRmMmQGd4SjkE0zxdjt+TUpZcuCIUG7yaHEh9STQV655I8rxKCB3hEWaKB3HALGgxZ0htIjQtZQ==}
 
-  '@vercel/koa@0.1.54':
-    resolution: {integrity: sha512-fUNQ6Wwp8gGT2KnoUH5Xv74eatFjza0cWwj60vY7zdymoNbuVNDBRLxFGiMUHl/wItzYuQIhPoaEeGiiYcuMDw==}
+  '@vercel/koa@0.1.56':
+    resolution: {integrity: sha512-5edjnf3QiTvVCucp+peZ8RICcGjaZqbsuD6dzl6DrSUvXfSPF9Enjv/OoUErZbRCTlRjyUw7nzGP8CLf7o7XMQ==}
 
-  '@vercel/nestjs@0.2.75':
-    resolution: {integrity: sha512-0wTm/Yp15Z3tvu8OFEvzQjXyC7R/77mGQ3vKn61LNxxxGztL2m0N+F2oIciEiIaHYszct3TbEkA6bUbUFBGDLA==}
+  '@vercel/nestjs@0.2.77':
+    resolution: {integrity: sha512-1nxP4Tcf+RQKkQA1f5bUXCUK8vhcnRzHocFiU2bE6+uu85UTaG13/VeUcYTQCmywPcomsPKi6u8B+S9fKv09xA==}
 
-  '@vercel/next@4.16.8':
-    resolution: {integrity: sha512-buiiOH7t8afdBHcF9vdIZ9z4LwA5hcTS9AUq6UlSY7qbKeeRUIgSVdz8QrYNvHhKMj/CAaTB92C/k25u9U9Muw==}
+  '@vercel/next@4.17.1':
+    resolution: {integrity: sha512-nEQRgGyU8+VU/zeKsBF89aKmL0Yu5VWWhTbaltp2V+1q6kHUo6Ho4+YS/COAgOrIwoe2nWr9liLVPltrftqG+Q==}
 
   '@vercel/nft@1.5.0':
     resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.7.13':
-    resolution: {integrity: sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==}
+  '@vercel/node@5.7.15':
+    resolution: {integrity: sha512-o8YtafKgaYsY7/4SRKlrvTx/cEB5o3vQG3/eq5Qo66n4WaFeZV8R8GG+BzSU3SYozasQlQxkbPxedUNF4sZJ8A==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -4224,23 +4225,23 @@ packages:
   '@vercel/prepare-flags-definitions@0.2.1':
     resolution: {integrity: sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==}
 
-  '@vercel/python-analysis@0.11.0':
-    resolution: {integrity: sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==}
+  '@vercel/python-analysis@0.11.1':
+    resolution: {integrity: sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==}
 
-  '@vercel/python@6.36.0':
-    resolution: {integrity: sha512-GLCX2JV2zfjGoSaANWi6gfL1z1IO02ulFhDOGYlOwBmVb1qQFLLssTnbN5uDO5heWm5Owi2/eqBG+l2E7TXiVQ==}
+  '@vercel/python@6.38.0':
+    resolution: {integrity: sha512-/idmN2pnaRkgdFTSSGdnGE0V/cUPM36sxMF4YPQMxPA2mTx8cFG/BPO1ZJSzo8Yv2ajdXwDUVgAKruFMbQ+9bw==}
 
-  '@vercel/redwood@2.4.12':
-    resolution: {integrity: sha512-8kJ7eEerI4iMpKVRxQCsnxiIwRVsWtyirEbYb4erCqqsJymTu/xrjhsfAUuzeP8qkuYGP82MJVK+hpKlFtsjGw==}
+  '@vercel/redwood@2.4.13':
+    resolution: {integrity: sha512-pXWzVctZea/J7WMQstjsYUDiMc6oJF72p8J5YZnLSCJWg7m+/dLzYGfaUSEo6Q0JpiO/NOcDmG3WENpn7kHwzg==}
 
-  '@vercel/remix-builder@5.7.2':
-    resolution: {integrity: sha512-bfStsDBQramYbWugelfyp1szTuDOLQ+ZELvgA9cpYc4FucgCrDy/bpvMMvsjiDACB9PoDzLrG//ZBgsic9yAhg==}
+  '@vercel/remix-builder@5.8.1':
+    resolution: {integrity: sha512-DDuT8NbIUoc1Fso2er0GyHxQR77au+BJr8wToDJcyoKjsypOHMcPwV8Vak9XsOfSUlQHLt1x9XnfTVj5O48Ssw==}
 
   '@vercel/ruby@2.3.2':
     resolution: {integrity: sha512-okIgMmPEePyDR9TZYaKM4oftcxVHM5Dbdl7V/tIdh3lq8MGLi7HR5vvQglmZUwZOeovE6MVtezxl960EOzeIiQ==}
 
-  '@vercel/rust@1.1.1':
-    resolution: {integrity: sha512-y6GYEQ8ltRRD8JNmSt0kWars7IMKjm1Nv26rFgl9wWVFqe5UeAvAHohiTX7D6W0Yowx6v+BnR3czeoVHwQvEMg==}
+  '@vercel/rust@1.2.0':
+    resolution: {integrity: sha512-JryMtBa0sFuqxfHpjrNgMks06XDKa8DVhGljTsoo26dIKqsoqeYhJHuepEAEXT+b5N+tUmxIOUcRq5//ewvytQ==}
 
   '@vercel/sandbox@1.9.0':
     resolution: {integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==}
@@ -4271,11 +4272,11 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/static-build@2.9.21':
-    resolution: {integrity: sha512-LnaroK/z97iAwg0vNHECQHAm2oaFLSWiKqCZIETnv5RpIqDXgj/URBD8v+DNNSXWGXsYOk7ezLRuQnlpq3Jx5w==}
+  '@vercel/static-build@2.9.22':
+    resolution: {integrity: sha512-zkwy48kv+4UlL3TTC8uoX2nWPdKXAydkKE/D8QYFq895Nq/CDB19r1q5vXno2iO9/njDsfYdl0Ftk7nXcexzgw==}
 
-  '@vercel/static-config@3.2.0':
-    resolution: {integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==}
+  '@vercel/static-config@3.3.0':
+    resolution: {integrity: sha512-GpS3tPwUeDJCkrKbMNtS2XLRFgfxTlN7YNUL+Bo23+fGolrDw6Oq79R3yvxTYgqRaJMGSEqC7iMw6mj6I5loxg==}
 
   '@vitest/browser-playwright@4.1.5':
     resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
@@ -8146,14 +8147,6 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -8997,8 +8990,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vercel@52.0.0:
-    resolution: {integrity: sha512-yLQn/wrGWVjvoCKQJuqi+aZvy+yYNDY9tSWiq6sH3LlTZ8zdEIHS7hB07TTsYTLQQWb55rW0h5d05QPExMVcSA==}
+  vercel@53.2.0:
+    resolution: {integrity: sha512-r4fzI7LSnzhYn2L4acMHmRk1V6WgfjFFzaei0AgG0bd2b17HF9HeRoP9BxJD/yvYmjLIfYIoGTd0CWlIGg3rUg==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -9387,7 +9380,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9409,7 +9402,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.2
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
@@ -9420,7 +9413,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12833,9 +12826,9 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/backends@0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
+  '@vercel/backends@0.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
     dependencies:
-      '@vercel/build-utils': 13.20.0
+      '@vercel/build-utils': 13.21.0
       '@vercel/nft': 1.5.0(rollup@4.60.3)
       '@yarnpkg/parsers': 3.0.3
       execa: 3.2.0
@@ -12864,15 +12857,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.25.0
 
-  '@vercel/build-utils@13.20.0':
+  '@vercel/build-utils@13.21.0':
     dependencies:
-      '@vercel/python-analysis': 0.11.0
+      '@vercel/python-analysis': 0.11.1
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.0.55(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
+  '@vercel/cervel@0.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
     dependencies:
-      '@vercel/backends': 0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
+      '@vercel/backends': 0.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -12883,23 +12876,23 @@ snapshots:
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.71(rollup@4.60.3)':
+  '@vercel/elysia@0.1.73(rollup@4.60.3)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/error-utils@2.0.3': {}
+  '@vercel/error-utils@2.1.0': {}
 
-  '@vercel/express@0.1.81(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
+  '@vercel/express@0.1.83(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)':
     dependencies:
-      '@vercel/cervel': 0.0.55(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
+      '@vercel/cervel': 0.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
       '@vercel/nft': 1.5.0(rollup@4.60.3)
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
       fs-extra: 11.1.0
       path-to-regexp: 8.4.2
       ts-morph: 12.0.0
@@ -12912,10 +12905,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vercel/fastify@0.1.74(rollup@4.60.3)':
+  '@vercel/fastify@0.1.76(rollup@4.60.3)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -12949,30 +12942,30 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.1.21':
+  '@vercel/gatsby-plugin-vercel-builder@2.2.0':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.20.0
+      '@vercel/build-utils': 13.21.0
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/go@3.5.0': {}
+  '@vercel/go@3.6.0': {}
 
-  '@vercel/h3@0.1.80(rollup@4.60.3)':
+  '@vercel/h3@0.1.82(rollup@4.60.3)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.74(rollup@4.60.3)':
+  '@vercel/hono@0.2.76(rollup@4.60.3)':
     dependencies:
       '@vercel/nft': 1.5.0(rollup@4.60.3)
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
       fs-extra: 11.1.0
       path-to-regexp: 8.4.2
       ts-morph: 12.0.0
@@ -12982,30 +12975,30 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/hydrogen@1.3.6':
+  '@vercel/hydrogen@1.3.7':
     dependencies:
-      '@vercel/static-config': 3.2.0
+      '@vercel/static-config': 3.3.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.54(rollup@4.60.3)':
+  '@vercel/koa@0.1.56(rollup@4.60.3)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.75(rollup@4.60.3)':
+  '@vercel/nestjs@0.2.77(rollup@4.60.3)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/node': 5.7.15(rollup@4.60.3)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/next@4.16.8(rollup@4.60.3)':
+  '@vercel/next@4.17.1(rollup@4.60.3)':
     dependencies:
       '@vercel/nft': 1.5.0(rollup@4.60.3)
     transitivePeerDependencies:
@@ -13032,16 +13025,16 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.7.13(rollup@4.60.3)':
+  '@vercel/node@5.7.15(rollup@4.60.3)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.20.0
-      '@vercel/error-utils': 2.0.3
+      '@vercel/build-utils': 13.21.0
+      '@vercel/error-utils': 2.1.0
       '@vercel/nft': 1.5.0(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/static-config': 3.3.0
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
       edge-runtime: 2.5.9
@@ -13065,7 +13058,7 @@ snapshots:
 
   '@vercel/prepare-flags-definitions@0.2.1': {}
 
-  '@vercel/python-analysis@0.11.0':
+  '@vercel/python-analysis@0.11.1':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
@@ -13075,26 +13068,26 @@ snapshots:
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  '@vercel/python@6.36.0':
+  '@vercel/python@6.38.0':
     dependencies:
-      '@vercel/python-analysis': 0.11.0
+      '@vercel/python-analysis': 0.11.1
 
-  '@vercel/redwood@2.4.12(rollup@4.60.3)':
+  '@vercel/redwood@2.4.13(rollup@4.60.3)':
     dependencies:
       '@vercel/nft': 1.5.0(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
-      semver: 6.3.1
+      '@vercel/static-config': 3.3.0
+      semver: 7.7.4
       ts-morph: 12.0.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/remix-builder@5.7.2(rollup@4.60.3)':
+  '@vercel/remix-builder@5.8.1(rollup@4.60.3)':
     dependencies:
-      '@vercel/error-utils': 2.0.3
+      '@vercel/error-utils': 2.1.0
       '@vercel/nft': 1.5.0(rollup@4.60.3)
-      '@vercel/static-config': 3.2.0
+      '@vercel/static-config': 3.3.0
       path-to-regexp: 6.1.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
@@ -13105,7 +13098,7 @@ snapshots:
 
   '@vercel/ruby@2.3.2': {}
 
-  '@vercel/rust@1.1.1':
+  '@vercel/rust@1.2.0':
     dependencies:
       execa: 5.1.1
       smol-toml: 1.5.2
@@ -13130,14 +13123,14 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/static-build@2.9.21':
+  '@vercel/static-build@2.9.22':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.1.21
-      '@vercel/static-config': 3.2.0
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.0
+      '@vercel/static-config': 3.3.0
       ts-morph: 12.0.0
 
-  '@vercel/static-config@3.2.0':
+  '@vercel/static-config@3.3.0':
     dependencies:
       ajv: 8.6.3
       json-schema-to-ts: 1.6.4
@@ -14657,7 +14650,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -14686,7 +14679,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -14744,7 +14737,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.6
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -16120,7 +16113,7 @@ snapshots:
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.7.4
 
   make-dir@4.0.0:
     dependencies:
@@ -16723,7 +16716,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
-      semver: 6.3.1
+      semver: 7.7.4
 
   node-fetch@2.6.11:
     dependencies:
@@ -16774,7 +16767,7 @@ snapshots:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 5.7.2
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@5.0.0:
@@ -17906,10 +17899,6 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  semver@5.7.2: {}
-
-  semver@6.3.1: {}
-
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
@@ -18854,31 +18843,31 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vercel@52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3):
+  vercel@53.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3):
     dependencies:
-      '@vercel/backends': 0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
+      '@vercel/backends': 0.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
       '@vercel/blob': 2.3.0
-      '@vercel/build-utils': 13.20.0
+      '@vercel/build-utils': 13.21.0
       '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.71(rollup@4.60.3)
-      '@vercel/express': 0.1.81(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
-      '@vercel/fastify': 0.1.74(rollup@4.60.3)
+      '@vercel/elysia': 0.1.73(rollup@4.60.3)
+      '@vercel/express': 0.1.83(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.3)(typescript@6.0.3)
+      '@vercel/fastify': 0.1.76(rollup@4.60.3)
       '@vercel/fun': 1.3.0
-      '@vercel/go': 3.5.0
-      '@vercel/h3': 0.1.80(rollup@4.60.3)
-      '@vercel/hono': 0.2.74(rollup@4.60.3)
-      '@vercel/hydrogen': 1.3.6
-      '@vercel/koa': 0.1.54(rollup@4.60.3)
-      '@vercel/nestjs': 0.2.75(rollup@4.60.3)
-      '@vercel/next': 4.16.8(rollup@4.60.3)
-      '@vercel/node': 5.7.13(rollup@4.60.3)
+      '@vercel/go': 3.6.0
+      '@vercel/h3': 0.1.82(rollup@4.60.3)
+      '@vercel/hono': 0.2.76(rollup@4.60.3)
+      '@vercel/hydrogen': 1.3.7
+      '@vercel/koa': 0.1.56(rollup@4.60.3)
+      '@vercel/nestjs': 0.2.77(rollup@4.60.3)
+      '@vercel/next': 4.17.1(rollup@4.60.3)
+      '@vercel/node': 5.7.15(rollup@4.60.3)
       '@vercel/prepare-flags-definitions': 0.2.1
-      '@vercel/python': 6.36.0
-      '@vercel/redwood': 2.4.12(rollup@4.60.3)
-      '@vercel/remix-builder': 5.7.2(rollup@4.60.3)
+      '@vercel/python': 6.38.0
+      '@vercel/redwood': 2.4.13(rollup@4.60.3)
+      '@vercel/remix-builder': 5.8.1(rollup@4.60.3)
       '@vercel/ruby': 2.3.2
-      '@vercel/rust': 1.1.1
-      '@vercel/static-build': 2.9.21
+      '@vercel/rust': 1.2.0
+      '@vercel/static-build': 2.9.22
       chokidar: 4.0.0
       esbuild: 0.27.0
       form-data: 4.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,4 +35,5 @@ overrides:
   '@hono/node-server@<1.19.10': 2.0.1
   'effect@>=3.0.0 <3.20.0': 3.21.2
   'undici@<6.21.1': 8.1.0
+  'semver@<7': ^7.7.4
   vite: ^7.3.1


### PR DESCRIPTION
Renovate PR #2271 updated the hono override to 4.12.17 in pnpm-workspace.yaml but the lockfile was not regenerated, causing CI to fail with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on every job that runs `pnpm i --frozen-lockfile`.

Regenerating the lockfile with the existing trustPolicy: no-downgrade guard tripped on semver@5.7.2 and semver@6.3.1, which lack provenance attestations while semver@7.x carries them. Add a `semver@<7: ^7.7.4` override so all sub-7 semver references resolve to a provenance-backed 7.x release; this keeps the supply-chain hardening intact and lets the lockfile regenerate cleanly. The hono override now matches between workspace and lockfile.