### PR TITLE
chore(ci): introduce setup-pnpm composite action

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -1,0 +1,48 @@
+name: "Setup pnpm + Node"
+description: "Composite action: checkout (optional), pnpm + Node + dependency install with integrated cache"
+
+inputs:
+  checkout:
+    description: "Run actions/checkout. Set to 'false' if the caller already checked out."
+    required: false
+    default: "true"
+  submodules:
+    description: "Forwarded to actions/checkout (true|false|recursive)"
+    required: false
+    default: "true"
+  install:
+    description: "Run 'pnpm i --frozen-lockfile' after setup."
+    required: false
+    default: "true"
+  registry-url:
+    description: "Forwarded to actions/setup-node (used by npm publish flows)."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout files
+      if: ${{ inputs.checkout == 'true' }}
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+        submodules: ${{ inputs.submodules }}
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+      with:
+        run_install: false
+
+    - name: Install Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version-file: ".nvmrc"
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Install dependencies
+      if: ${{ inputs.install == 'true' }}
+      shell: bash
+      run: pnpm i --frozen-lockfile

--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -1,15 +1,7 @@
 name: "Setup pnpm + Node"
-description: "Composite action: checkout (optional), pnpm + Node + dependency install with integrated cache"
+description: "pnpm + Node + dependency install with integrated cache. Caller must checkout the repo first."
 
 inputs:
-  checkout:
-    description: "Run actions/checkout. Set to 'false' if the caller already checked out."
-    required: false
-    default: "true"
-  submodules:
-    description: "Forwarded to actions/checkout (true|false|recursive)"
-    required: false
-    default: "true"
   install:
     description: "Run 'pnpm i --frozen-lockfile' after setup."
     required: false
@@ -22,13 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout files
-      if: ${{ inputs.checkout == 'true' }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-        submodules: ${{ inputs.submodules }}
-
     - name: Install pnpm
       uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,25 +14,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Build docs (TypeDoc + DB schema)
         run: pnpm docs:build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,6 +14,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Build docs (TypeDoc + DB schema)

--- a/.github/workflows/jscpd.yaml
+++ b/.github/workflows/jscpd.yaml
@@ -9,26 +9,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Run jscpd
         id: jscpd

--- a/.github/workflows/jscpd.yaml
+++ b/.github/workflows/jscpd.yaml
@@ -9,6 +9,12 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Run jscpd

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -11,6 +11,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Generate license summary

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -11,25 +11,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Generate license summary
         run: pnpm license:summary

--- a/.github/workflows/mutation-test.yaml
+++ b/.github/workflows/mutation-test.yaml
@@ -15,25 +15,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm test:mutation:core
 
       - name: Upload mutation report

--- a/.github/workflows/mutation-test.yaml
+++ b/.github/workflows/mutation-test.yaml
@@ -15,6 +15,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm test:mutation:core
 

--- a/.github/workflows/prisma-deploy.yaml
+++ b/.github/workflows/prisma-deploy.yaml
@@ -15,25 +15,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm --filter s-database prisma:generate
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DIRECT_URL }}

--- a/.github/workflows/prisma-deploy.yaml
+++ b/.github/workflows/prisma-deploy.yaml
@@ -15,6 +15,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm --filter s-database prisma:generate
         env:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -41,19 +41,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-pnpm
         with:
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
+          submodules: "false"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build packages
         run: pnpm --filter "./packages/*" build

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -41,9 +41,12 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup-pnpm
         with:
-          submodules: "false"
           registry-url: "https://registry.npmjs.org"
 
       - name: Build packages


### PR DESCRIPTION
## Summary
- 全ワークフローで重複していた checkout + pnpm + Node + install のセットアップ4ステップを `.github/actions/setup-pnpm/` 配下の composite action に集約
- 影響軽微な6ワークフロー (docs / license-check / jscpd / mutation-test / prisma-deploy / release-please) を新しい composite に差し替え
- ci.yaml / memlab.yaml / update-reports.yaml への適用は後続 PR (#chore/ci-consolidate-env-anchors) に分離

## Why split
ci.yaml は build/test の本番影響が大きく、composite に潜在バグがあった場合のロールバック範囲を限定したいため、まず小ワークフローでの動作確認を兼ねて先行マージする。

## Test plan
- [ ] `license-check`, `jscpd` は PR の自動実行で緑になる
- [ ] `docs` は workflow_dispatch でグリーンを確認 (push to main トリガーのため)
- [ ] `mutation-test` は packages/core の差分が無いと走らないので、後続のPRで動作確認可能
- [ ] `prisma-deploy`, `release-please` は main マージ後の最初のトリガーで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)