### PR TITLE
refactor(ci): consolidate ci/memlab env via YAML anchor and unify cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm build
         env: &build_env
@@ -61,8 +67,6 @@ jobs:
           fi
 
       - uses: ./.github/actions/setup-pnpm
-        with:
-          checkout: "false"
       - run: pnpm check:ci
 
   eslint:
@@ -73,6 +77,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-eslint-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm lint
         env:
@@ -86,6 +96,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-knip-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm knip
 
@@ -97,6 +113,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-test-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm --filter "./packages/*" build
       - run: pnpm exec playwright install
@@ -116,6 +138,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-storybook-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm storybook:build
         env:
@@ -128,6 +156,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-docs-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - name: Build TypeDoc
         run: pnpm docs:build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,3 @@
-# FIXME: refactor for multiple declaration and cache
 name: ci
 permissions:
   pull-requests: write
@@ -16,29 +15,9 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          # version: X.X.X
-          # Optional when there is a packageManager field in the package.json.
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm build
-        env:
+        env: &build_env
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
@@ -81,19 +60,9 @@ jobs:
             exit 1
           fi
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+      - uses: ./.github/actions/setup-pnpm
         with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+          checkout: "false"
       - run: pnpm check:ci
 
   eslint:
@@ -104,25 +73,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-eslint-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm lint
         env:
           SKIP_ENV_VALIDATION: "true"
@@ -135,25 +86,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-knip-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm knip
 
   test:
@@ -164,52 +97,11 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-test-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Get pnpm directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm --filter "./packages/*" build
       - run: pnpm exec playwright install
       - run: pnpm test
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
-          PUSHOVER_APP_TOKEN: ${{ secrets.PUSHOVER_APP_TOKEN }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-          AUTH0_ISSUER_BASE_URL: ${{ secrets.AUTH0_ISSUER_BASE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_REPORT_URL: ${{ secrets.SENTRY_REPORT_URL }}
-          MINIO_HOST: ${{ secrets.MINIO_HOST }}
-          MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
-          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
-          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          QDRANT_COLLECTION_NAME: ${{ secrets.QDRANT_COLLECTION_NAME }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+        env: *build_env
       - name: Show coverage
         if: always()
         uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
@@ -224,27 +116,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-storybook-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          # version: X.X.X
-          # Optional when there is a packageManager field in the package.json.
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm storybook:build
         env:
           SKIP_ENV_VALIDATION: "true"
@@ -256,25 +128,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-docs-${{ github.ref }}
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
-
+      - uses: ./.github/actions/setup-pnpm
       - name: Build TypeDoc
         run: pnpm docs:build

--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -11,32 +11,14 @@ jobs:
     permissions: {}
     timeout-minutes: 30
     steps:
-      - name: Checkout files
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install Chrome for Puppeteer
         run: pnpm dlx puppeteer@24.40.0 browsers install chrome
 
       - name: Build application
         run: pnpm build
-        env:
+        env: &build_env
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
@@ -58,25 +40,7 @@ jobs:
 
       - name: Start server
         run: pnpm --filter s-private-app start > server.log 2>&1 &
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
-          PUSHOVER_APP_TOKEN: ${{ secrets.PUSHOVER_APP_TOKEN }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-          AUTH0_ISSUER_BASE_URL: ${{ secrets.AUTH0_ISSUER_BASE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_REPORT_URL: ${{ secrets.SENTRY_REPORT_URL }}
-          MINIO_HOST: ${{ secrets.MINIO_HOST }}
-          MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
-          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
-          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          QDRANT_COLLECTION_NAME: ${{ secrets.QDRANT_COLLECTION_NAME }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+        env: *build_env
 
       - name: Wait for server
         run: |

--- a/.github/workflows/memlab.yaml
+++ b/.github/workflows/memlab.yaml
@@ -11,6 +11,12 @@ jobs:
     permissions: {}
     timeout-minutes: 30
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Install Chrome for Puppeteer

--- a/.github/workflows/update-reports.yaml
+++ b/.github/workflows/update-reports.yaml
@@ -13,6 +13,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - name: Checkout files
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm license:summary
       - run: pnpm jscpd:summary

--- a/.github/workflows/update-reports.yaml
+++ b/.github/workflows/update-reports.yaml
@@ -13,34 +13,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
-        with:
-          run_install: false
-
-      - name: Get pnpm directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: pnpm i --frozen-lockfile # && npm install -g @lhci/cli@0.12.x
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm license:summary
       - run: pnpm jscpd:summary
       - run: pnpm check:fix


### PR DESCRIPTION
## Summary
- ci.yaml を全 job 移行: setup-pnpm composite を採用、build job に \`&build_env\` で20シークレット env を定義、test job から \`*build_env\` で参照することで重複を解消
- ci.yaml 行頭の \`# FIXME: refactor for multiple declaration and cache\` コメントを削除（解消済み）
- ci.yaml test job の未使用 \`STORE_PATH=\$(pnpm store path)\` 取得処理を削除
- memlab.yaml も同様に \`&build_env\` / \`*build_env\` で env 重複を解消
- update-reports.yaml の手動 \`actions/cache\` を撤廃し、他ワークフローと同じ \`actions/setup-node\` 統合キャッシュに統一

## Base branch
このPRは #2283 (\`chore/ci-setup-pnpm-composite\`) をベースにしています。先にそちらをマージ・rebase してください。

## Verification
- ローカルで js-yaml により ci.yaml/memlab.yaml の YAML アンカー展開を検証済み
- ci.yaml の build/test、memlab.yaml の build/start-server で env が同じ18変数として正しく展開されることを確認

## Test plan
- [ ] PR の自動実行で ci.yaml の全 job (build/biome/eslint/knip/test/storybook/docs) が緑になる
- [ ] memlab は workflow_dispatch でグリーンを確認 (build と Start server で同じ env が効くこと)
- [ ] update-reports は workflow_dispatch でグリーンを確認 (PR作成 step は検証時にコメントアウトすると安全)

🤖 Generated with [Claude Code](https://claude.com/claude-code)