### PR TITLE
feat(database): bridge Vercel Supabase POSTGRES_* to DATABASE_URL/DIRECT_URL

### DIFF
--- a/app/src/env.ts
+++ b/app/src/env.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import "@s-hirano-ist/s-database/resolve-db-env";
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
@@ -30,6 +31,8 @@ export const env = createEnv({
 			.default("development"),
 		/** @example "postgresql://USERNAME:PASSWORD@IP_ADDRESS:PORT/DB_NAME?schema=SCHEMA_NAME" */
 		DATABASE_URL: z.string(),
+		/** Direct (non-pooled) connection URL used by Prisma migrations. */
+		DIRECT_URL: z.string(),
 		PUSHOVER_URL: z
 			.string()
 			.default("https://api.pushover.net/1/messages.json"),
@@ -73,6 +76,7 @@ export const env = createEnv({
 	runtimeEnv: {
 		NODE_ENV: process.env.NODE_ENV,
 		DATABASE_URL: process.env.DATABASE_URL,
+		DIRECT_URL: process.env.DIRECT_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
 		PUSHOVER_APP_TOKEN: process.env.PUSHOVER_APP_TOKEN,

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -1,3 +1,4 @@
+import "@s-hirano-ist/s-database/resolve-db-env";
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -10,6 +10,7 @@
 			"types": "./src/index.ts",
 			"default": "./src/index.ts"
 		},
+		"./resolve-db-env": "./src/resolve-db-env.ts",
 		"./generated": "./src/generated/index.js",
 		"./generated/*": "./src/generated/*"
 	},
@@ -20,6 +21,7 @@
 				"types": "./src/index.ts",
 				"default": "./src/index.ts"
 			},
+			"./resolve-db-env": "./src/resolve-db-env.ts",
 			"./generated": "./src/generated/index.js",
 			"./generated/*": "./src/generated/*"
 		},

--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -12,6 +12,7 @@
  * @module
  */
 
+import "./src/resolve-db-env";
 import { defineConfig } from "prisma/config";
 
 /**
@@ -41,6 +42,6 @@ export default defineConfig({
 		path: "prisma/migrations",
 	},
 	datasource: {
-		url: process.env.DIRECT_URL ?? process.env.DATABASE_URL ?? "",
+		url: process.env.DIRECT_URL ?? "",
 	},
 });

--- a/packages/database/src/resolve-db-env.ts
+++ b/packages/database/src/resolve-db-env.ts
@@ -1,0 +1,8 @@
+// Side-effect module: aliases Vercel Supabase Marketplace env vars
+// (POSTGRES_PRISMA_URL / POSTGRES_URL_NON_POOLING) to the canonical
+// names Prisma expects. Import this before any code reads
+// process.env.DATABASE_URL or DIRECT_URL.
+process.env.DATABASE_URL ??=
+	process.env.POSTGRES_PRISMA_URL ?? process.env.POSTGRES_URL;
+process.env.DIRECT_URL ??=
+	process.env.POSTGRES_URL_NON_POOLING ?? process.env.DATABASE_URL;


### PR DESCRIPTION
## Summary

- Vercel Supabase Marketplace Integrationが注入する `POSTGRES_PRISMA_URL` / `POSTGRES_URL_NON_POOLING` を、Prismaが期待する `DATABASE_URL` / `DIRECT_URL` に副作用モジュールでエイリアス。Vercelダッシュボードでの手動 `DATABASE_URL` 設定を不要にする。
- 副作用モジュール [packages/database/src/resolve-db-env.ts](packages/database/src/resolve-db-env.ts) を新規作成し、`env.ts` / `prisma.config.ts` / `instrumentation.ts` の各エントリーから最先頭で import。`??=` を使うため、ローカル(Doppler)/CI(GitHub Secrets)で既に `DATABASE_URL` がセットされている環境には影響なし。
- `DIRECT_URL` を `app/src/env.ts` の server schema に追加(マイグレーション・スクリプト用)。Vercel上はIntegrationが提供する non-pooling URL から、ローカル/CIでは `DATABASE_URL` から自動 fallback。

## 解決される問題

Vercel Supabase Integrationは PostgreSQL接続情報を `POSTGRES_*` 系の固定名で注入し、UIで変数名のリマッピングはサポートされていない (2026-05時点)。本プロジェクトは伝統的に `DATABASE_URL` を読むため、Integration導入時に Vercel ダッシュボードで `DATABASE_URL` を手動追加する必要があった。本PRでアプリ側fallbackを実装し、Integration完結を実現する。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| [packages/database/src/resolve-db-env.ts](packages/database/src/resolve-db-env.ts) | 新規。副作用で `process.env.DATABASE_URL` / `DIRECT_URL` を解決 |
| [packages/database/package.json](packages/database/package.json) | `exports` に `./resolve-db-env` を追加 |
| [packages/database/prisma.config.ts](packages/database/prisma.config.ts) | 副作用 import追加、`url` を `DIRECT_URL` のみに簡素化 |
| [app/src/env.ts](app/src/env.ts) | 副作用 import追加、`DIRECT_URL` を server schema / runtimeEnv に追加 |
| [app/src/instrumentation.ts](app/src/instrumentation.ts) | 副作用 import追加 (defense-in-depth) |

## 動作

| 環境 | `DATABASE_URL` 解決元 |
|---|---|
| ローカル開発 (Doppler) | Doppler の `DATABASE_URL` (`??=` が no-op) |
| CI (GitHub Actions) | GitHub Secrets `DATABASE_URL` (同上) |
| Vercel Preview / Production | Integration の `POSTGRES_PRISMA_URL` から fallback |

## Test plan

- [x] `pnpm --filter s-private-app typecheck` 通過
- [x] `pnpm --filter @s-hirano-ist/s-database typecheck` 通過
- [ ] CI上で全ジョブ (build / biome / eslint / knip / test / storybook / docs) が通ること
- [ ] Vercel Preview Deployment で Function ログに `[Article.findMany] took Xms` が出ること(runtime接続成功の証拠)
- [ ] Sentry でデプロイ後 1時間以内に `PrismaClientInitializationError` が発生しないこと

## マージ後の任意作業

Vercel ダッシュボードに手動設定された `DATABASE_URL` がある場合、`??=` のため手動設定が優先される。Integration完結に切り替えたい場合は Vercel UI で `DATABASE_URL` を削除する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベース環境設定の解決ロジックを追加しました。Prismaマイグレーション時の接続設定が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->