### PR TITLE
fix(database): bridged Vercel-Supabase URLs failing TLS verification

### DIFF
--- a/packages/database/src/resolve-db-env.ts
+++ b/packages/database/src/resolve-db-env.ts
@@ -2,7 +2,21 @@
 // (POSTGRES_PRISMA_URL / POSTGRES_URL_NON_POOLING) to the canonical
 // names Prisma expects. Import this before any code reads
 // process.env.DATABASE_URL or DIRECT_URL.
-process.env.DATABASE_URL ??=
-	process.env.POSTGRES_PRISMA_URL ?? process.env.POSTGRES_URL;
+//
+// Vercel-Supabase URLs do not include `sslmode`, but Supabase's pooler
+// presents a cert chain (Supabase root CA) that Node.js does not trust
+// by default — strict verification surfaces as `SELF_SIGNED_CERT_IN_CHAIN`.
+// Append `sslmode=no-verify` (idempotent) so @prisma/adapter-pg / pg can
+// establish the TLS session.
+function withNoVerifySsl(url: string | undefined) {
+	if (!url) return url;
+	if (/[?&]sslmode=/i.test(url)) return url;
+	return `${url}${url.includes("?") ? "&" : "?"}sslmode=no-verify`;
+}
+
+process.env.DATABASE_URL ??= withNoVerifySsl(
+	process.env.POSTGRES_PRISMA_URL ?? process.env.POSTGRES_URL,
+);
 process.env.DIRECT_URL ??=
-	process.env.POSTGRES_URL_NON_POOLING ?? process.env.DATABASE_URL;
+	withNoVerifySsl(process.env.POSTGRES_URL_NON_POOLING) ??
+	process.env.DATABASE_URL;


### PR DESCRIPTION
## Summary

- 本番で `prisma.category.findMany()` 等の Prisma 操作が `Error opening a TLS connection: self-signed certificate in certificate chain` (P1011 / TlsConnectionError) で失敗していた問題の修正。
- 原因は Vercel-Supabase Marketplace が注入する `POSTGRES_PRISMA_URL` / `POSTGRES_URL_NON_POOLING` に `sslmode` が含まれず、`@prisma/adapter-pg` (pg) が Supabase root CA を検証できずに `SELF_SIGNED_CERT_IN_CHAIN` を起こすため。
- `resolve-db-env.ts` の橋渡しに `sslmode=no-verify` の冪等補完を追加。明示的に `DATABASE_URL` を設定するローカル/CI には影響しない。

## Test plan

- [ ] Preview デプロイで `/[locale]` 等 Category 取得を伴うルートを開き、TLS エラーが解消することを確認
- [ ] ローカル開発 (Doppler 経由の `DATABASE_URL`) で `pnpm dev` が従来通り起動することを確認
- [ ] `pnpm prisma:migrate` 等の `DIRECT_URL` 利用パスが影響を受けないことを確認
- [ ] `POSTGRES_PRISMA_URL` に既に `?sslmode=...` がある変則ケースで二重付与されないことを動作確認 (regex で skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)