### PR TITLE
fix(build): run prisma generate before next build on Vercel

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "doppler run -- next dev",
-		"build": "if [ -n \"$CI\" ]; then next build; else doppler run -- next build; fi",
+		"build": "if [ -n \"$CI\" ]; then pnpm --filter @s-hirano-ist/s-database prisma:generate && next build; else doppler run -- next build; fi",
 		"analyze": "doppler run -- next experimental-analyze",
 		"start": "if [ -n \"$CI\" ]; then next start; else doppler run -- next start; fi",
 		"typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

- Vercelのbuildで `Module not found: Can't resolve './generated'` (packages/database/src/index.ts) が発生していた問題を修正。
- `app/package.json` の `build` スクリプトで、CI/Vercel環境では `next build` の前に `pnpm --filter @s-hirano-ist/s-database prisma:generate` を明示的に実行するよう変更。
- ローカル開発パス (`doppler run -- next build`) は変更なし。

## 背景

`packages/database/src/generated/` は gitignore されており、ビルド時に毎回生成する必要がある。GitHub Actions ではルートから `pnpm build` (= `pnpm --recursive build`) が走るため、`packages/database` の build script が `prisma generate` を実行してから `app` がビルドされていた。

しかしVercel上では、`pnpm --recursive build` の topological order と並列実行の組み合わせ（おそらくpnpm 11のlifecycle挙動変更が影響）で、`app` の `next build` が `packages/database` の `prisma generate` 完了前に走り出していたと推測される。

`app` のbuildが自前で `prisma generate` を実行するようにすることで、recursive実行の順序やpostinstallの挙動に依存せず、確実にgenerated clientが存在する状態で `next build` を開始できる。

## Test plan

- [ ] Vercel preview deploy が成功すること
- [ ] GitHub Actions の `build` job が引き続き成功すること
- [ ] ローカルで `cd app && doppler run -- next build` が従来通り動くこと
- [ ] ローカルで `cd app && CI=1 pnpm build` がエラーなく完走すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)