### PR TITLE
Clean up pnpm overrides and disable Renovate for workspace config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -131,5 +131,12 @@
       ],
       enabled: false,
     },
+    {
+      matchFileNames: [
+        'pnpm-workspace.yaml',
+      ],
+      enabled: false,
+      description: 'pnpm-workspace.yaml overrides act as security/compat floors; bumping them mutates the file without regenerating pnpm-lock.yaml, which trips ERR_PNPM_LOCKFILE_CONFIG_MISMATCH under pnpm v11 --frozen-lockfile. Update manually when a new vuln requires raising the floor.',
+    },
   ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,17 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  cross-spawn@<7.0.5: 7.0.6
-  tar@<7.5.8: 7.5.13
-  minimatch@>=10.0.0 <10.2.1: 10.2.5
-  path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
-  picomatch@>=4.0.0 <4.0.4: 4.0.4
-  hono@<4.12.4: 4.12.17
-  '@hono/node-server@<1.19.10': 2.0.1
-  effect@>=3.0.0 <3.20.0: 3.21.2
-  undici@<6.21.1: 8.1.0
-  semver@<7: ^7.7.4
   vite: ^7.3.1
+  semver@<7: ^7.7.4
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,14 +26,7 @@ blockExoticSubdeps: true
 trustPolicy: no-downgrade
 
 overrides:
-  'cross-spawn@<7.0.5': 7.0.6
-  'tar@<7.5.8': 7.5.13
-  'minimatch@>=10.0.0 <10.2.1': 10.2.5
-  'path-to-regexp@>=8.0.0 <8.4.0': 8.4.2
-  'picomatch@>=4.0.0 <4.0.4': 4.0.4
-  'hono@<4.12.4': 4.12.17
-  '@hono/node-server@<1.19.10': 2.0.1
-  'effect@>=3.0.0 <3.20.0': 3.21.2
-  'undici@<6.21.1': 8.1.0
-  'semver@<7': ^7.7.4
+  # Pinned to v7 so Storybook nextjs-vite remains compatible (see commit b058f2c)
   vite: ^7.3.1
+  # Required while trustPolicy: no-downgrade rejects semver@5/6 (no provenance attestation; see commit 1d05046)
+  'semver@<7': ^7.7.4


### PR DESCRIPTION
## Summary
This PR removes outdated dependency overrides from `pnpm-workspace.yaml` and disables Renovate automation for the workspace configuration file to prevent lockfile mismatches.

## Key Changes
- **Removed 9 outdated override entries** from `pnpm-workspace.yaml` that are no longer needed for security or compatibility
- **Retained 2 critical overrides** with explanatory comments:
  - `vite: ^7.3.1` - pinned to v7 for Storybook nextjs-vite compatibility
  - `semver@<7: ^7.7.4` - required due to trustPolicy constraints with older semver versions lacking provenance attestation
- **Disabled Renovate automation** for `pnpm-workspace.yaml` to prevent automatic updates that would cause lockfile mismatches under pnpm v11's `--frozen-lockfile` mode
- **Added detailed documentation** explaining why manual updates are required for workspace overrides

## Implementation Details
The Renovate configuration now includes a rule that disables automated updates for `pnpm-workspace.yaml`, with a clear explanation that bumping overrides without regenerating `pnpm-lock.yaml` triggers `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` errors. This ensures the lockfile and workspace configuration remain in sync.

https://claude.ai/code/session_01CBNWziZDqQZ6uarozmjka5