### PR TITLE
fix(deps): suspend pnpm trustPolicy to unblock Renovate lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 - **Supply Chain Protection**
   - Package version pinning (`savePrefix: ''` in pnpm-workspace.yaml)
   - Lifecycle script protection (`allowBuilds` + `strictDepBuilds: true`)
-  - Exotic subdep blocking (`blockExoticSubdeps: true`) and trust policy (`trustPolicy: no-downgrade`)
+  - Exotic subdep blocking (`blockExoticSubdeps: true`)
   - Minimum release age: 24 hours (pnpm-workspace.yaml)
   - Frozen lockfiles in CI/CD
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,16 +118,14 @@ allowBuilds:
 ```yaml
 strictDepBuilds: true
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
 ```
 
 | 設定 | 役割 |
 |------|------|
 | `strictDepBuilds: true` | `allowBuilds` 未登録のパッケージがライフサイクルスクリプトを持つ場合、インストールをハードエラー化（pnpm 10 までは警告のみ） |
 | `blockExoticSubdeps: true` | 推移的依存が npm レジストリ以外のソース（Git URL / tarball URL）から取得されることをブロック。直接依存は対象外 |
-| `trustPolicy: no-downgrade` | パッケージの信頼レベル（provenance / trusted publisher 等）が以前より低下した場合にインストールをブロック。パッケージ乗っ取り攻撃への対策 |
 
-例外を設けたい場合は `trustPolicyExclude` で個別に `package@version` を指定する。
+> Note: `trustPolicy: no-downgrade` は Renovate / Dependabot 側が `ERR_PNPM_TRUST_DOWNGRADE` を握りつぶして lockfile 更新ジョブごと落ちるため一時撤去中（[pnpm-workspace.yaml](pnpm-workspace.yaml) の TODO コメント参照）。代替として下記の Minimum Release Age + 手動レビューで provenance 低下監視を担保。
 
 ### Minimum Release Age
 
@@ -211,11 +209,10 @@ pnpm i --frozen-lockfile
 2. **Lifecycle Script Protection**: `allowBuilds` で承認済みパッケージのみスクリプト実行可能
 3. **Strict Build Enforcement**: `strictDepBuilds: true` で未登録パッケージの build script をハードエラー化
 4. **Exotic Subdep Blocking**: `blockExoticSubdeps: true` で npm レジストリ以外由来の推移的依存を遮断
-5. **Trust Policy**: `trustPolicy: no-downgrade` でパッケージ乗っ取り（provenance 低下）を検知
-6. **Minimum Release Age**: 2-3日の Renovate delay
-7. **Frozen Lockfiles**: Reproducible builds in CI/CD
-8. **Automated Monitoring**: Renovate tracks vulnerabilities
-9. **Manual Auditing**: `pnpm audit` for on-demand checks
+5. **Minimum Release Age**: 2-3日の Renovate delay
+6. **Frozen Lockfiles**: Reproducible builds in CI/CD
+7. **Automated Monitoring**: Renovate tracks vulnerabilities
+8. **Manual Auditing**: `pnpm audit` for on-demand checks
 
 ### Package Installation Safety
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,6 @@ import { ArticlesStackLoader } from "@/loaders/articles";
 - **バージョン固定**: pnpm-workspace.yamlの`savePrefix: ''`
 - **ライフサイクルスクリプト保護**: `allowBuilds`（明示許可制）+ `strictDepBuilds: true`で未登録パッケージのスクリプト実行をハードエラー化
 - **推移的依存の制限**: `blockExoticSubdeps: true`でnpmレジストリ以外（Git/tarball URL）由来の間接依存をブロック
-- **信頼レベル監視**: `trustPolicy: no-downgrade`でパッケージ乗っ取り（provenance低下）を検知
 - **CI/CD**: 全CIワークフローで`--frozen-lockfile`を強制
 - **最小リリース経過時間**: 新規公開された悪意のあるパッケージを避けるための24時間グローバル設定
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,14 @@ allowBuilds:
 # pnpm 11 supply-chain security hardening
 strictDepBuilds: true
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# TODO: 再有効化検討 — `trustPolicy: no-downgrade` は Renovate / Dependabot 側で
+# `ERR_PNPM_TRUST_DOWNGRADE` を握りつぶし lockfile 更新ジョブが落ちるため一時撤去。
+# 参照: https://github.com/dependabot/dependabot-core/issues/14077
+#       https://github.com/orgs/pnpm/discussions/10706
+# 再有効化条件: Renovate がこのエラーを recoverable として扱い、該当バージョンを
+# スキップして lockfile を生成できるようになった時点で復活させる。
+# 現状の代替防御: Renovate の minimumReleaseAge('2 days') + strictDepBuilds
+# + blockExoticSubdeps + allowBuilds 明示許可 + 手動レビュー。
 
 overrides:
   'cross-spawn@<7.0.5': 7.0.6


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` から `trustPolicy: no-downgrade` を一時撤去し、再有効化検討用の TODO コメント（撤去理由・参照リンク・再有効化条件・代替防御）を残置
- 関連ドキュメント (`SECURITY.md`, `docs/architecture.md`, `README.md`) を撤去後の状態に同期

## Why

`trustPolicy: no-downgrade` は新バージョンの provenance / 署名証跡が前バージョンより弱い場合に install を `ERR_PNPM_TRUST_DOWNGRADE` で失敗させる pnpm v11 のサプライチェーン保護機能。Renovate / Dependabot のいずれもこのエラーを握りつぶし、`pnpm install --lockfile-only` ジョブごと失敗するため、`package.json` だけ更新されて `pnpm-lock.yaml` が更新されない PR が量産される状態だった。

現在 open な Renovate PR は #2261, #2274, #2276, #2277, #2278, #2279, #2282, #2179 — すべて lockfile を含まずブロック中。pnpm メンテナ自身が discussions で「この機能は off by default」「代替として `minimumReleaseAge` を推奨」と明言。

代替防御は既存設定で担保される:
- Renovate `minimumReleaseAge: '2 days'`
- `strictDepBuilds: true`（lifecycle script のハードエラー化）
- `blockExoticSubdeps: true`（npm 以外由来の推移的依存遮断）
- `allowBuilds` 明示許可リスト
- CI 全 job で `--frozen-lockfile`
- 手動レビュー（`s-hirano-ist`）

## References

- https://github.com/dependabot/dependabot-core/issues/14077
- https://github.com/orgs/pnpm/discussions/10706

## Test plan

- [x] `pnpm install --lockfile-only` がエラーなく完了し lockfile に差分が出ないことを確認
- [x] `pnpm install --frozen-lockfile` で既存 lockfile との整合性を確認
- [x] `git grep "trustPolicy"` で残存が SECURITY.md の Note と pnpm-workspace.yaml の TODO コメントのみであることを確認
- [ ] CI (`.github/workflows/ci.yaml`) 全 job が green になること
- [ ] マージ後、Dependency Dashboard #14 の "rebase all open PRs" を発火し、Renovate PR が `pnpm-lock.yaml` を含む形で再生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * セキュリティ設定ドキュメントを更新し、セキュリティ構成の説明を変更しました。

* **Chores**
  * 依存関係管理設定を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->