### PR TITLE
chore: cleanup eslint-plugin-import dep & mitigate Renovate OOM

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,8 @@
     'nvm',
   ],
   dependencyDashboard: true,
-  branchConcurrentLimit: 3,
-  prConcurrentLimit: 5,
+  branchConcurrentLimit: 1,
+  prConcurrentLimit: 3,
   separateMultipleMajor: false,
   schedule: [
     'before 11am on monday',
@@ -34,10 +34,10 @@
   rangeStrategy: 'bump',
   platformAutomerge: true,
   automergeStrategy: 'squash',
+  // Mend Cloud で全 workspace 一括再生成が OOM の主因となるため停止。
+  // 必要時はローカルで `pnpm install` を回して手動 PR を作る。
   lockFileMaintenance: {
-    enabled: true,
-    automerge: true,
-    schedule: ['before 5am on the first day of the month'],
+    enabled: false,
   },
   vulnerabilityAlerts: {
     labels: [

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
 		"eslint-config-next": "16.2.4",
 		"eslint-import-resolver-typescript": "4.4.4",
 		"eslint-plugin-boundaries": "6.0.2",
-		"eslint-plugin-import": "2.32.0",
 		"eslint-plugin-jsx-a11y": "6.10.2",
 		"eslint-plugin-react-hooks": "7.1.1",
 		"eslint-plugin-storybook": "10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       eslint-plugin-boundaries:
         specifier: 6.0.2
         version: 6.0.2(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
-      eslint-plugin-import:
-        specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
         version: 6.10.2(eslint@10.3.0(jiti@2.7.0))
@@ -14770,7 +14767,7 @@ snapshots:
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.3.0(jiti@2.7.0))
@@ -14848,17 +14845,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.3.0(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
@@ -14885,35 +14871,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 10.3.0(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
-      hasown: 2.0.3
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -14925,7 +14882,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,10 @@ allowBuilds:
   sleep: true
   unrs-resolver: true
 
+# Renovate (Mend Cloud) で `pnpm install --recursive` が OOM Killer に
+# SIGKILL される事象の回避。pnpm 11 の workspace 並列解決のメモリピークを抑制。
+childConcurrency: 1
+
 # pnpm 11 supply-chain security hardening
 strictDepBuilds: true
 blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

2つの軽微な保守作業をまとめたPR。

- **eslint-plugin-import の明示エントリ削除**: `eslint-config-next` が同バージョンを hard dependency で要求しているため devDependencies の明示エントリは冗長。`eslint.config.js` でも直接 import されておらず、`import/resolver` 設定は `eslint-plugin-boundaries` が `eslint-module-utils` 経由で消費するため挙動は不変。
- **Renovate (Mend Cloud) の OOM 対策**: `pnpm install --recursive` が SIGKILL されていた問題への緩和。
  - `pnpm-workspace.yaml` に `childConcurrency: 1` を追加（pnpm 11 の workspace 並列解決のメモリピーク抑制）
  - `branchConcurrentLimit`: 3 → 1, `prConcurrentLimit`: 5 → 3
  - `lockFileMaintenance` を無効化（全 workspace 一括再生成が OOM の主因）。必要時はローカルで `pnpm install` して手動 PR を作る運用に切替

## Test plan

- [x] `pnpm install` 成功・`pnpm-lock.yaml` の `eslint-plugin-import@2.32.0` は `eslint-config-next` 経由で残存
- [x] `pnpm lint` 実行 → 0 errors / 既存 warning のみ（増減なし）
- [x] `pnpm knip` で `eslint-plugin-import` への新規指摘なし
- [ ] Renovate の次回ジョブが OOM せず完走することを観測

🤖 Generated with [Claude Code](https://claude.com/claude-code)