### PR TITLE
revert: pnpm/Renovate OOM 緩和策 (#2296 の 51cee7fe)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,8 @@
     'nvm',
   ],
   dependencyDashboard: true,
-  branchConcurrentLimit: 1,
-  prConcurrentLimit: 3,
+  branchConcurrentLimit: 3,
+  prConcurrentLimit: 5,
   separateMultipleMajor: false,
   schedule: [
     'before 11am on monday',
@@ -34,10 +34,10 @@
   rangeStrategy: 'bump',
   platformAutomerge: true,
   automergeStrategy: 'squash',
-  // Mend Cloud で全 workspace 一括再生成が OOM の主因となるため停止。
-  // 必要時はローカルで `pnpm install` を回して手動 PR を作る。
   lockFileMaintenance: {
-    enabled: false,
+    enabled: true,
+    automerge: true,
+    schedule: ['before 5am on the first day of the month'],
   },
   vulnerabilityAlerts: {
     labels: [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,10 +20,6 @@ allowBuilds:
   sleep: true
   unrs-resolver: true
 
-# Renovate (Mend Cloud) で `pnpm install --recursive` が OOM Killer に
-# SIGKILL される事象の回避。pnpm 11 の workspace 並列解決のメモリピークを抑制。
-childConcurrency: 1
-
 # pnpm 11 supply-chain security hardening
 strictDepBuilds: true
 blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

- PR #2296 で導入した `51cee7fe fix(renovate): reduce concurrency to avoid OOM on Mend Cloud` を revert します
- `childConcurrency: 1` / `branchConcurrentLimit: 1` / `prConcurrentLimit: 3` / `lockFileMaintenance: { enabled: false }` のいずれも Mend Cloud 側の OOM を解消できなかったため、効果のない制約だけ残るのを避ける目的です
- PR #2296 のもう一方のコミット `c342fe8b chore(deps): remove redundant eslint-plugin-import explicit entry` は無関係なので残します

## Test plan

- [ ] `git diff main..HEAD` が `51cee7fe` の打ち消しのみであることを確認
- [ ] CI green
- [ ] マージ後、Renovate が `lockFileMaintenance` を再び実行する（毎月 1 日 5am 前）かをモニタ。再び OOM が出るようなら別アプローチで対処

🤖 Generated with [Claude Code](https://claude.com/claude-code)