### PR TITLE
refactor(ui): migrate class-variance-authority to tailwind-variants

### DIFF
--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -7,7 +7,7 @@
  * This package provides reusable React components built with:
  * - Radix UI primitives for accessibility
  * - Tailwind CSS for styling
- * - class-variance-authority for variant management
+ * - tailwind-variants for variant management
  *
  * ## Component Categories
  *

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -107,7 +107,6 @@
 	"license": "MIT",
 	"dependencies": {
 		"@tailwindcss/typography": "0.5.19",
-		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",
 		"cmdk": "1.1.1",
 		"lucide-react": "1.11.0",
@@ -126,7 +125,8 @@
 		"remark-gfm": "4.0.1",
 		"sonner": "2.0.7",
 		"@base-ui/react": "1.4.1",
-		"tailwind-merge": "3.5.0"
+		"tailwind-merge": "3.5.0",
+		"tailwind-variants": "3.2.2"
 	},
 	"devDependencies": {
 		"@storybook/nextjs-vite": "10.3.5",

--- a/packages/ui/ui/badge.tsx
+++ b/packages/ui/ui/badge.tsx
@@ -1,9 +1,9 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { cn } from "../utils/cn";
 
 /**
- * Badge style variants using class-variance-authority.
+ * Badge style variants using tailwind-variants.
  *
  * @remarks
  * Provides consistent styling for badge components with multiple visual variants.
@@ -13,25 +13,23 @@ import { cn } from "../utils/cn";
  * const className = badgeVariants({ variant: "secondary" });
  * ```
  */
-const badgeVariants = cva(
-	"inline-flex items-center rounded-full border px-3 py-0.5 text-xs font-medium transition-colors focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2",
-	{
-		variants: {
-			variant: {
-				default:
-					"border-primary/20 bg-primary/5 text-primary hover:bg-primary/10",
-				secondary:
-					"border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
-				destructive:
-					"border-transparent bg-destructive/10 text-destructive hover:bg-destructive/20",
-				outline: "border-muted bg-muted/50 text-muted-foreground",
-			},
-		},
-		defaultVariants: {
-			variant: "default",
+const badgeVariants = tv({
+	base: "inline-flex items-center rounded-full border px-3 py-0.5 text-xs font-medium transition-colors focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2",
+	variants: {
+		variant: {
+			default:
+				"border-primary/20 bg-primary/5 text-primary hover:bg-primary/10",
+			secondary:
+				"border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
+			destructive:
+				"border-transparent bg-destructive/10 text-destructive hover:bg-destructive/20",
+			outline: "border-muted bg-muted/50 text-muted-foreground",
 		},
 	},
-);
+	defaultVariants: {
+		variant: "default",
+	},
+});
 
 /**
  * Props for the Badge component.
@@ -47,7 +45,7 @@ export type BadgeProps = {} & React.HTMLAttributes<HTMLDivElement> &
  *
  * @remarks
  * Badges are used to highlight information like status, counts, or labels.
- * Built on top of class-variance-authority for consistent styling.
+ * Built on top of tailwind-variants for consistent styling.
  *
  * @param props - Badge props including variant and standard div attributes
  * @returns A styled badge element

--- a/packages/ui/ui/button.tsx
+++ b/packages/ui/ui/button.tsx
@@ -1,11 +1,11 @@
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { cn } from "../utils/cn";
 
 /**
- * Button style variants using class-variance-authority.
+ * Button style variants using tailwind-variants.
  *
  * @remarks
  * Provides consistent button styling with multiple visual variants and sizes.
@@ -25,40 +25,38 @@ import { cn } from "../utils/cn";
  * const className = buttonVariants({ variant: "outline", size: "lg" });
  * ```
  */
-const buttonVariants = cva(
-	"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 active:scale-[0.97] focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
-	{
-		variants: {
-			variant: {
-				default:
-					"bg-linear-to-r from-primary to-primary-grad text-white shadow-[0_2px_16px_rgb(var(--primary)/0.3)] hover:shadow-[0_4px_24px_rgb(var(--primary)/0.45)] hover:brightness-110",
-				destructive:
-					"bg-destructive text-white shadow-[0_2px_16px_rgb(var(--destructive)/0.3)] hover:shadow-[0_4px_24px_rgb(var(--destructive)/0.45)] hover:brightness-110",
-				outline:
-					"border border-foreground/10 bg-background/60 backdrop-blur-sm shadow-xs hover:bg-background/90 hover:shadow-md hover:border-primary/30",
-				secondary:
-					"bg-muted/60 text-muted-foreground backdrop-blur-sm shadow-xs hover:bg-muted/80",
-				ghost: "hover:text-primary hover:bg-primary/5",
-				link: "text-white underline-offset-4 hover:underline",
-				navSide: "rounded-full hover:bg-primary/10 transition-all duration-200",
-				navCenter:
-					"bg-linear-to-br from-primary to-primary-grad text-white rounded-full shadow-[0_4px_20px_rgb(var(--primary)/0.4)] ring-4 ring-background hover:scale-110 hover:shadow-[0_6px_28px_rgb(var(--primary)/0.5)] active:scale-95 transition-all duration-200",
-			},
-			size: {
-				default: "h-9 px-4 py-2",
-				sm: "h-8 rounded-md px-3 text-xs",
-				lg: "h-10 rounded-md px-8",
-				icon: "size-9",
-				navSide: "size-full",
-				navCenter: "size-14 rounded-full",
-			},
+const buttonVariants = tv({
+	base: "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 active:scale-[0.97] focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
+	variants: {
+		variant: {
+			default:
+				"bg-linear-to-r from-primary to-primary-grad text-white shadow-[0_2px_16px_rgb(var(--primary)/0.3)] hover:shadow-[0_4px_24px_rgb(var(--primary)/0.45)] hover:brightness-110",
+			destructive:
+				"bg-destructive text-white shadow-[0_2px_16px_rgb(var(--destructive)/0.3)] hover:shadow-[0_4px_24px_rgb(var(--destructive)/0.45)] hover:brightness-110",
+			outline:
+				"border border-foreground/10 bg-background/60 backdrop-blur-sm shadow-xs hover:bg-background/90 hover:shadow-md hover:border-primary/30",
+			secondary:
+				"bg-muted/60 text-muted-foreground backdrop-blur-sm shadow-xs hover:bg-muted/80",
+			ghost: "hover:text-primary hover:bg-primary/5",
+			link: "text-white underline-offset-4 hover:underline",
+			navSide: "rounded-full hover:bg-primary/10 transition-all duration-200",
+			navCenter:
+				"bg-linear-to-br from-primary to-primary-grad text-white rounded-full shadow-[0_4px_20px_rgb(var(--primary)/0.4)] ring-4 ring-background hover:scale-110 hover:shadow-[0_6px_28px_rgb(var(--primary)/0.5)] active:scale-95 transition-all duration-200",
 		},
-		defaultVariants: {
-			variant: "default",
-			size: "default",
+		size: {
+			default: "h-9 px-4 py-2",
+			sm: "h-8 rounded-md px-3 text-xs",
+			lg: "h-10 rounded-md px-8",
+			icon: "size-9",
+			navSide: "size-full",
+			navCenter: "size-14 rounded-full",
 		},
 	},
-);
+	defaultVariants: {
+		variant: "default",
+		size: "default",
+	},
+});
 
 /**
  * Props for the Button component.
@@ -78,7 +76,7 @@ export type ButtonProps = {
  * A versatile button component with multiple variants and sizes.
  *
  * @remarks
- * The Button component is built on top of class-variance-authority for
+ * The Button component is built on top of tailwind-variants for
  * consistent styling and supports the Radix UI Slot pattern for composition.
  *
  * @param props - Button props including variant, size, and standard button attributes

--- a/packages/ui/ui/dialog.tsx
+++ b/packages/ui/ui/dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { cn } from "../utils/cn";
 
@@ -75,21 +75,19 @@ function DialogOverlay({ className, ref, ...props }: DialogOverlayProps) {
 }
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const dialogContentVariants = cva(
-	"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg",
-	{
-		variants: {
-			size: {
-				default: "max-w-lg",
-				md: "max-w-2xl",
-				lg: "max-w-4xl",
-			},
-		},
-		defaultVariants: {
-			size: "default",
+const dialogContentVariants = tv({
+	base: "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg",
+	variants: {
+		size: {
+			default: "max-w-lg",
+			md: "max-w-2xl",
+			lg: "max-w-4xl",
 		},
 	},
-);
+	defaultVariants: {
+		size: "default",
+	},
+});
 
 type DialogContentProps = {
 	ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;

--- a/packages/ui/ui/label.tsx
+++ b/packages/ui/ui/label.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import * as LabelPrimitive from "@radix-ui/react-label";
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { cn } from "../utils/cn";
 
 /**
- * Label style variants using class-variance-authority.
+ * Label style variants using tailwind-variants.
  * @internal
  */
-const labelVariants = cva(
-	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-);
+const labelVariants = tv({
+	base: "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+});
 
 /**
  * Props for the Label component.

--- a/packages/ui/ui/rating.tsx
+++ b/packages/ui/ui/rating.tsx
@@ -1,9 +1,10 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { cn } from "../utils/cn";
 
-const ratingVariants = cva("flex gap-0.5", {
+const ratingVariants = tv({
+	base: "flex gap-0.5",
 	variants: {
 		size: {
 			sm: "[&_svg]:size-3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,9 +411,6 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
-      class-variance-authority:
-        specifier: 0.7.1
-        version: 0.7.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -450,6 +447,9 @@ importers:
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
+      tailwind-variants:
+        specifier: 3.2.2
+        version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.4)
     devDependencies:
       '@storybook/nextjs-vite':
         specifier: 10.3.5
@@ -8747,6 +8747,16 @@ packages:
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwind-variants@3.2.2:
+    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
 
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
@@ -18659,6 +18669,12 @@ snapshots:
       tailwindcss: 4.2.4
 
   tailwind-merge@3.5.0: {}
+
+  tailwind-variants@3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.4):
+    dependencies:
+      tailwindcss: 4.2.4
+    optionalDependencies:
+      tailwind-merge: 3.5.0
 
   tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4):
     dependencies:


### PR DESCRIPTION
## Summary

- `class-variance-authority` (last published 2024-11、機能完成系として停滞) を active メンテの `tailwind-variants` に置き換え
- 両ライブラリの `VariantProps` 型ヘルパーは同名・互換のため API 1:1 移行 (`cva(base, opts)` → `tv({ base, ...opts })`)
- `compoundVariants` 未使用のため挙動は同一。対象は [button](packages/ui/ui/button.tsx) / [badge](packages/ui/ui/badge.tsx) / [rating](packages/ui/ui/rating.tsx) / [label](packages/ui/ui/label.tsx) / [dialog](packages/ui/ui/dialog.tsx) の5ファイル

## Test plan

- [ ] `pnpm typecheck` 全 workspace 通過
- [ ] `pnpm test --project components` グリーン (既存 880 テスト)
- [ ] `pnpm --filter @s-hirano-ist/s-ui build` 通過、`dist/` から `class-variance-authority` 参照が消えている
- [ ] `pnpm storybook` で button / badge / rating / label / dialog の各 variant が視覚的に同一

🤖 Generated with [Claude Code](https://claude.com/claude-code)