### PR TITLE
fix(ci): pin depcruise action to Node 24

### DIFF
--- a/.github/workflows/depcruise.yaml
+++ b/.github/workflows/depcruise.yaml
@@ -15,6 +15,11 @@ jobs:
           persist-credentials: false
           submodules: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+
       - uses: MH4GF/dependency-cruiser-report-action@885013e37581e3472385ffa93c821b3505336bc1 # v2.5.3
         with:
           package-manager: pnpm


### PR DESCRIPTION
## Summary

- `MH4GF/dependency-cruiser-report-action@v2.5.3` 内部で Node 20 が使われており、pnpm 11 (`>=22.13` 必須) が `node:sqlite` モジュール解決に失敗してクラッシュする
- アクションの直前に `actions/setup-node@v6` を追加し、`.nvmrc` (24.15.0) の Node を PATH に通すことで、グローバルインストールされる pnpm が動作するようにする
- 影響範囲: 全PRの depcruise CI ジョブ。現在 .ts/.tsx を含む変更があるとほぼ確実に失敗していた

## Test plan

- [ ] このPRの depcruise ジョブが pass する
- [ ] PR #2301 / #2302 が rebase 後に depcruise を pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)