### PR TITLE
ci(renovate): skip lifecycle scripts to avoid Mend Cloud OOM

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,10 @@
     'mise',
     'nvm',
   ],
+  // Mend Cloud で pnpm install の lifecycle scripts (sharp / @prisma/engines /
+  // @sentry/cli / esbuild) がメモリを使い切り OOM kill される問題への対処。
+  // CI (--frozen-lockfile) と本番 deploy 側の install では通常通りバイナリを取得する。
+  ignoreScripts: true,
   dependencyDashboard: true,
   branchConcurrentLimit: 3,
   prConcurrentLimit: 5,
@@ -36,8 +40,8 @@
   automergeStrategy: 'squash',
   lockFileMaintenance: {
     enabled: true,
-    automerge: true,
-    schedule: ['before 5am on the first day of the month'],
+    automerge: false,
+    schedule: ['before 5am on the first day of january,april,july,october'],
   },
   vulnerabilityAlerts: {
     labels: [


### PR DESCRIPTION
## Summary
- Renovate runs on Mend Cloud were SIGKILLed during `pnpm install` because lifecycle scripts (sharp / @prisma/engines / @sentry/cli / esbuild) blew past the kernel memory cap. Add `ignoreScripts: true` so Renovate skips them; CI (`--frozen-lockfile`) and production deploy still fetch the native binaries.
- Drop `lockFileMaintenance` from monthly automerge to **quarterly (Jan/Apr/Jul/Oct) with manual review** — full lockfile regen is the single heaviest install, so de-risk frequency and let humans gate the resulting big diff.

## Why this approach
Past attempt (`51cee7f`) reduced concurrency + disabled lockFileMaintenance and didn't help, because the OOM is driven by per-install peak memory, not concurrency. Lifecycle scripts (native binary downloads / Prisma engines) are the actual hotspot — `ignoreScripts` removes them from Renovate's install only, and lockfile resolution is unchanged.

If OOM persists after this lands, the next step is migrating to a self-hosted Renovate via `renovatebot/github-action` with `NODE_OPTIONS=--max-old-space-size=...`. Out of scope here.

## Test plan
- [x] `npx --yes --package=renovate -- renovate-config-validator .github/renovate.json5` passes locally
- [ ] `renovate-config-validator.yaml` workflow passes on this PR
- [ ] After merge: trigger a Force run from Mend dashboard; confirm no SIGKILL/OOM in logs and PRs are produced
- [ ] Verify generated PRs have correct `pnpm-lock.yaml` diffs and no stray build artifacts
- [ ] CI (`pnpm build` / `pnpm test` / `pnpm typecheck`) is green on a Renovate-generated PR (CI installs scripts normally)
- [ ] One scheduled Monday run completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)