### PR TITLE
ci(renovate): self-host Renovate on GitHub Actions to escape Mend Cloud OOM

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,41 @@
+name: renovate
+
+permissions: {}
+
+on:
+  schedule:
+    # 00:00 UTC Mon = 09:00 JST Mon。renovate.json5 内の
+    # `before 11am on monday` 設定で PR 生成ウィンドウは Renovate 側でゲートされる。
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: ログレベル
+        type: choice
+        default: info
+        options: [info, debug]
+      dryRun:
+        description: dry-run (書き込みなしでログ出力のみ)
+        type: boolean
+        default: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    concurrency:
+      group: renovate
+      cancel-in-progress: false
+    steps:
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          # Mend Cloud は 3GB cap で OOM kill されていたため self-host へ移行。
+          # ubuntu-24.04 runner は ~7GB メモリを持つので Node ヒープに 6GB 割り当てる。
+          NODE_OPTIONS: --max-old-space-size=6144
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_PLATFORM: github

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,9 +18,22 @@ on:
         description: dry-run (書き込みなしでログ出力のみ)
         type: boolean
         default: false
+  # Dependency Dashboard issue のチェックボックス操作で Renovate を再起動する。
+  # 例: "Check this box to trigger a request for Renovate to run again"。
+  issues:
+    types: [edited]
+  # Renovate が作った PR 上の rebase/retry チェックボックスにも反応する。
+  pull_request:
+    types: [edited]
 
 jobs:
   renovate:
+    # 無関係な issue/PR 編集では走らないように絞り込む。
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.issue.title == 'Dependency Dashboard') ||
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'renovate/'))
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency:


### PR DESCRIPTION
## Summary
- Mend Cloud は `kernel-out-of-memory` (3GB cap) でリポ抽出フェーズの時点で落ちており、`ignoreScripts: true` を入れても install 前にOOMするため救えなかった (job `019e0d10-0392-7d60-88a5-21d57df0336b` 参照)。
- self-hosted Renovate を `.github/workflows/renovate.yaml` で動かす。`ubuntu-24.04` runner (~7GB) + `NODE_OPTIONS=--max-old-space-size=6144` で 3GB 上限から脱出。
- `.github/renovate.json5` は無変更。Mend が注入していた `mergeConfidence:all-badges` などのオーバーヘッドも消えるので二重で軽くなる。

## ⚠️ マージ前に必要な手動セットアップ

### 1. fine-grained PAT を作成して `RENOVATE_TOKEN` 秘匿変数として登録

GitHub → Settings → Developer settings → Personal access tokens → **Fine-grained tokens** → "Generate new token"

- **Resource owner**: `s-hirano-ist`
- **Repository access**: Only select repositories → `s-private`
- **Repository permissions**:
  - Contents: **Read and write** (ブランチ push)
  - Pull requests: **Read and write** (PR 作成・automerge)
  - Workflows: **Read and write** (Renovate がCI workflowファイルを更新する場合)
  - Issues: **Read and write** (Dependency Dashboard issue)
  - Metadata: **Read** (必須・自動付与)
- **Expiration**: 90日もしくは1年 (期限切れ前にローテーション)

生成したトークンを repo settings → Secrets and variables → Actions → New repository secret に **`RENOVATE_TOKEN`** で登録。

### 2. Mend Renovate App をこのリポからアンインストール

GitHub → Settings → Integrations → GitHub Apps → Mend Renovate → **Configure** → Repository access から `s-private` を外す（または `Suspend` / `Uninstall`）。これをやらないと **Mend Cloud と self-hosted の両方が走って PR が二重作成される**。

### 3. (任意) 動作確認

マージ後、Actions タブから `renovate` workflow を **Run workflow** で手動 trigger。`Dry run: true` で投げると書き込みなしで動作確認できる。

## なぜこの設計
- `cron: '0 0 * * 1'` = 09:00 JST 月曜。`renovate.json5` 内の `before 11am on monday` で PR 生成タイミングは Renovate 側ゲートのまま。
- `permissions: {}` — workflow 自体は GITHUB_TOKEN を使わず、PAT 経由で操作する。
- `concurrency: { group: renovate, cancel-in-progress: false }` — schedule と manual dispatch がぶつかってもキューイングされる。
- Action は SHA pin (`@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13`) で他の workflow の慣行に揃えた。

## Test plan
- [ ] PR 上で `github-actions-lint` workflow が green
- [ ] PR 上で `renovate-config-validator` workflow が green
- [ ] マージ前に `RENOVATE_TOKEN` secret 登録 + Mend uninstall を完了
- [ ] マージ後、`workflow_dispatch` (Dry run: true) で OOM が出ずに完走することを確認
- [ ] 翌週月曜の scheduled run で実際に PR が作成されることを確認
- [ ] Dependency Dashboard issue が新しい self-hosted runner 経由で更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Renovateによる自動依存関係更新ワークフローを追加しました。週次スケジュール実行と手動トリガーに対応し、実行時にログレベルとドライランを選択できます。
  * Issue/PRの編集をトリガーとして再実行可能になり、実行時間やメモリ上限が拡張され信頼性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->