### PR TITLE
ci(renovate): pin gitAuthor to PAT owner identity

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,3 +52,6 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
+          # PAT 所有者 (s-hirano-ist) を commit author に固定。
+          # 既定値の renovate@whitesourcesoftware.com は Mend 所有アドレスのため警告が出る。
+          RENOVATE_GIT_AUTHOR: "s-hirano-ist <s-hirano-ist@users.noreply.github.com>"


### PR DESCRIPTION
## Summary
self-hosted Renovate の初回実行ログで以下の警告が出ていた:

```
WARN: Using the default gitAuthor email address, renovate@whitesourcesoftware.com,
is not recommended on GitHub.com, as this corresponds to a user owned by Mend
```

デフォルトの gitAuthor が **Mend 所有のメールアドレス**になっていた（self-host になっても Renovate のデフォルトはMend用）。`RENOVATE_GIT_AUTHOR` を PAT 所有者 (`s-hirano-ist`) の GitHub noreply メールに固定して警告を解消する。

## ⚠️ 別途PAT権限の追加が必要

同じログで以下も出ていた:

```
WARN: Cannot access vulnerability alerts. Please ensure permissions have been granted.
```

これは PAT に **`Dependabot alerts: Read`** 権限が抜けているのが原因。これが無いとGitHubの12件のセキュリティアラートに対する `[SECURITY]` PR が作成されない。

→ **手動で fine-grained PAT を編集して `Dependabot alerts: Read` を追加してください。** workflow 側の対応は不要。

## Test plan
- [ ] PR マージ後、workflow_dispatch で動作確認
- [ ] 次回 scheduled run のログで `Using the default gitAuthor` 警告が消えていることを確認
- [ ] PAT 権限追加後、`Cannot access vulnerability alerts` 警告も消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)