### PR TITLE
ci(renovate): drop issues/PR edit triggers to break feedback loop

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,22 +18,16 @@ on:
         description: dry-run (書き込みなしでログ出力のみ)
         type: boolean
         default: false
-  # Dependency Dashboard issue のチェックボックス操作で Renovate を再起動する。
-  # 例: "Check this box to trigger a request for Renovate to run again"。
-  issues:
-    types: [edited]
-  # Renovate が作った PR 上の rebase/retry チェックボックスにも反応する。
-  pull_request:
-    types: [edited]
+  # NOTE: `issues: edited` トリガーは外している。Renovate 自身が
+  # Dependency Dashboard issue の body を毎回更新するため、トリガーを残すと
+  # 「Renovate run が dashboard を更新 → issues:edited が発火 → 別の run が起動」
+  # の自走ループになり大量の `repository-changed` abort を生む。
+  # PAT 所有者と人間ユーザが同一なので sender フィルタも効かない。
+  # Dashboard checkbox を toggle しても次の scheduled / workflow_dispatch run で
+  # 読み取られるので機能は失われない (即時反応しなくなるだけ)。
 
 jobs:
   renovate:
-    # 無関係な issue/PR 編集では走らないように絞り込む。
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && github.event.issue.title == 'Dependency Dashboard') ||
-      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'renovate/'))
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency:


### PR DESCRIPTION
## Summary
直前の self-host run で **`Repository has changed during renovation - aborting`** が連発していた原因がフィードバックループだと判明。

```
00:06:36 workflow_dispatch  ← 手動 run
00:04:22 issues             ← Renovate が dashboard を更新 → 自分自身を再起動
00:02:53 pull_request       skipped
00:01:49 workflow_dispatch  ← 手動 run
```

Renovate は実行のたびに **Dependency Dashboard issue の body を update** する。それが `issues: edited` event を発火 → workflow が再起動 → そのrunがまた dashboard を update… で自走する。PAT 所有者と人間ユーザが同一 (`s-hirano-ist`) なので sender でフィルタ不可。

`issues: edited` と `pull_request: edited` トリガーを削除。

## トレードオフ
- ✗ Dashboard checkbox を toggle しても **即時には反応しなくなる**
- ✓ 但し toggle した checkbox 状態は次回 scheduled run / workflow_dispatch で Renovate が読み取る (機能自体は失われない)
- ✓ 自走ループ消失 → 偽 abort も消える

## Test plan
- [ ] PR マージ後 workflow_dispatch で動作確認 (連続 abort せず PR が作られること)
- [ ] `gh run list --workflow=renovate.yaml` で `issues` event の run が出ないこと
- [ ] 既に作成済みの `renovate/non-major-dev` ブランチに対する PR が作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)