### PR TITLE
Migrate npm dependency management from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,11 @@
 version: 2
+# npm (pnpm) は Dependabot では扱わない。Dependabot のサポート上限は pnpm v10 で、
+# 本リポジトリの packageManager (pnpm@11) では npm ジョブが
+# "does not support your pnpm version" で失敗し PR が生成されないため。
+# pnpm v11 サポートは未対応 (dependabot/dependabot-core#14794)。
+# npm は Renovate (.github/renovate.json5) に任せ、Dependabot は pnpm 非依存の
+# github-actions / docker-compose のみを担当する。
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Asia/Tokyo
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-    versioning-strategy: increase
-    commit-message:
-      prefix: chore
-      include: scope
-    cooldown:
-      default-days: 2
-    groups:
-      production-non-major:
-        dependency-type: production
-        update-types:
-          - patch
-          - minor
-      development-non-major:
-        dependency-type: development
-        update-types:
-          - patch
-          - minor
-
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,18 +9,21 @@
 		":enableVulnerabilityAlertsWithLabel(security)",
 	],
 	reviewers: ["s-hirano-ist"],
-	// Dependabot がサポートしない範囲のみ Renovate で扱う:
+	// Dependabot が苦手な範囲を Renovate で扱う:
+	//   - npm: Dependabot のサポート上限は pnpm v10 で、packageManager (pnpm@11) では
+	//     npm ジョブが "does not support your pnpm version" で失敗するため Renovate に戻した
+	//     (dependabot/dependabot-core#14794)。
 	//   - mise / nvm: ツールバージョン管理
 	//   - lockFileMaintenance: 四半期に pnpm-lock 全リフレッシュ
-	// npm / github-actions / docker-compose は .github/dependabot.yml に移行済み。
-	enabledManagers: ["mise", "nvm"],
+	// github-actions / docker-compose は pnpm 非依存のため .github/dependabot.yml が担当。
+	enabledManagers: ["npm", "mise", "nvm"],
 	// Mend Cloud / self-host いずれでも pnpm install の lifecycle scripts (sharp /
 	// @prisma/engines / @sentry/cli / esbuild) によるメモリ消費を抑える保険。
 	// CI (--frozen-lockfile) と本番 deploy 側の install では通常通りバイナリを取得する。
 	ignoreScripts: true,
 	dependencyDashboard: true,
-	branchConcurrentLimit: 2,
-	prConcurrentLimit: 2,
+	branchConcurrentLimit: 3,
+	prConcurrentLimit: 5,
 	separateMultipleMajor: false,
 	schedule: ["before 11am on monday"],
 	labels: ["dependencies"],
@@ -37,6 +40,24 @@
 	},
 	packageRules: [
 		{
+			matchManagers: ["npm"],
+			matchUpdateTypes: ["patch", "minor"],
+			matchPackageNames: ["*"],
+			matchDepTypes: ["dependencies", "peerDependencies"],
+			groupName: "non-major",
+			minimumReleaseAge: "2 days",
+		},
+		{
+			matchManagers: ["npm"],
+			matchUpdateTypes: ["patch", "minor"],
+			matchPackageNames: ["*"],
+			matchDepTypes: ["devDependencies"],
+			groupName: "non-major (devDependencies)",
+			groupSlug: "non-major-dev",
+			minimumReleaseAge: "2 days",
+			automerge: true,
+		},
+		{
 			matchManagers: ["mise"],
 			groupName: "mise",
 			groupSlug: "mise",
@@ -45,7 +66,7 @@
 		},
 		{
 			matchDepNames: ["node", "pnpm"],
-			matchManagers: ["mise", "nvm"],
+			matchManagers: ["mise", "nvm", "npm"],
 			groupName: "node and pnpm",
 			groupSlug: "node-pnpm",
 			minimumReleaseAge: "2 days",

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -20,15 +20,13 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       - name: Enable auto-merge for low-risk updates
-        # Renovate 旧設定相当:
-        #   - devDependencies (npm) の patch/minor: automerge
+        # Dependabot が扱うのは github-actions / docker-compose のみ
+        # (npm/pnpm は Renovate 管轄。理由は .github/dependabot.yml 冒頭コメント参照)。
         #   - github-actions の patch/minor: automerge
         #   - docker-compose の patch/minor: automerge
-        # production deps と major は手動レビュー (auto-merge しない)。
+        # major は手動レビュー (auto-merge しない)。
         if: |
           steps.meta.outputs.update-type != 'version-update:semver-major' && (
-            (steps.meta.outputs.package-ecosystem == 'npm' &&
-              steps.meta.outputs.dependency-type == 'direct:development') ||
             steps.meta.outputs.package-ecosystem == 'github_actions' ||
             steps.meta.outputs.package-ecosystem == 'docker_compose'
           )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,11 +135,14 @@ import { ArticlesStackLoader } from "@/loaders/articles";
 
 ## セキュリティ
 
-### 自動依存関係管理（Renovate）
-- **スケジュール**: 週次更新（月曜日11時（JST）前）
-- **脆弱性アラート**: セキュリティ問題の自動PR（`security`ラベル付き）
-- **サプライチェーン保護**: パッチ/マイナーの最小リリース経過時間3日（72時間）、グローバル最小24時間
-- **設定**: [.github/renovate.json5](../.github/renovate.json5)を参照
+### 自動依存関係管理（Renovate + Dependabot）
+- **役割分担**:
+  - **Renovate**: npm（pnpm）/ mise / nvm / 四半期の lockFileMaintenance。npm を Renovate が担当するのは、Dependabot のサポート上限が pnpm v10 で、本リポジトリの `packageManager`（pnpm@11）では npm ジョブが `does not support your pnpm version` で失敗するため（pnpm v11 サポートは未対応: dependabot/dependabot-core#14794）。
+  - **Dependabot**: pnpm 非依存の github-actions / docker-compose。低リスク更新は `dependabot-auto-merge.yaml` で auto-merge。
+- **スケジュール**: Renovate は週次（月曜日11時（JST）前）、Dependabot は日次（09:00 JST）。
+- **脆弱性アラート**: セキュリティ問題の自動PR（`security`ラベル付き、Renovate）
+- **サプライチェーン保護**: パッチ/マイナーの最小リリース経過時間（cooldown）2日、グローバル最小24時間
+- **設定**: [.github/renovate.json5](../.github/renovate.json5) / [.github/dependabot.yml](../.github/dependabot.yml) を参照
 
 ### npm/pnpmセキュリティ設定
 - **バージョン固定**: pnpm-workspace.yamlの`savePrefix: ''`


### PR DESCRIPTION
## Summary

Migrated npm (pnpm) dependency management from Dependabot to Renovate due to Dependabot's incompatibility with pnpm v11. Dependabot's support ceiling is pnpm v10, causing npm jobs to fail with "does not support your pnpm version" error (see dependabot/dependabot-core#14794). Dependabot now handles only pnpm-independent ecosystems (github-actions, docker-compose).

## Key Changes

- **Dependabot configuration** (`.github/dependabot.yml`):
  - Removed npm package-ecosystem configuration
  - Retained github-actions and docker-compose (pnpm-independent)
  - Added detailed comment explaining pnpm v11 incompatibility and role division

- **Renovate configuration** (`.github/renovate.json5`):
  - Re-enabled npm manager in `enabledManagers`
  - Added npm-specific package rules for production/peer dependencies and devDependencies with 2-day minimum release age
  - Increased `branchConcurrentLimit` from 2 to 3 and `prConcurrentLimit` from 2 to 5
  - Updated node/pnpm grouping rule to include npm manager

- **Auto-merge workflow** (`.github/workflows/dependabot-auto-merge.yaml`):
  - Removed npm devDependencies auto-merge condition (now Renovate's responsibility)
  - Clarified that Dependabot only handles github-actions and docker-compose
  - Retained auto-merge for low-risk github-actions and docker-compose updates

- **Documentation** (`docs/architecture.md`):
  - Updated security section to reflect Renovate + Dependabot role division
  - Documented why npm is managed by Renovate (pnpm v11 support gap)
  - Updated schedule information and configuration file references

## Implementation Details

- Renovate's npm rules group non-major updates with 2-day cooldown, matching previous Dependabot behavior
- DevDependencies are auto-merged by Renovate (low-risk updates)
- Production dependencies require manual review
- Dependabot's daily schedule (09:00 JST) retained for github-actions/docker-compose
- Renovate's weekly schedule (Monday 11am JST) retained for npm/mise/nvm

https://claude.ai/code/session_019tQNmcQTiyN8qZdDe9TJG2