### PR TITLE
ci(renovate): grant App token vulnerability_alerts:read for security PRs

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -56,12 +56,16 @@ jobs:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # 生成トークンを最小権限に限定（metadata:read は常時付与）。
-          #   contents       : ブランチ・コミット・lockfile 更新
-          #   pull-requests  : PR 作成・automerge 有効化
-          #   issues         : Dependency Dashboard issue の維持
+          #   contents            : ブランチ・コミット・lockfile 更新
+          #   pull-requests       : PR 作成・automerge 有効化
+          #   issues              : Dependency Dashboard issue の維持
+          #   vulnerability-alerts: Dependabot alerts を読み security ラベル付き脆弱性 PR を作る
+          #     （renovate.json5 の vulnerabilityAlerts / :enableVulnerabilityAlertsWithLabel の前提。
+          #      App 側にも "Dependabot alerts: Read" の付与が必要。無いとトークン発行が 422）。
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-vulnerability-alerts: read
 
       # self-host 実行。repo 設定 .github/renovate.json5 は Renovate が自動検出する
       # （configurationFile はグローバル設定用なので渡さない）。


### PR DESCRIPTION
## なぜ

Dependency Dashboard に `⚠️ WARN: Cannot access vulnerability alerts. Please ensure permissions have been granted.` が出ていた。

`renovate.json5` は `vulnerabilityAlerts` / `:enableVulnerabilityAlertsWithLabel(security)` を有効化しており（SECURITY.md でも security-first 施策として明記）、Renovate は GitHub の脆弱性アラート（Dependabot alerts）を読んで `security` ラベル付き脆弱性 PR を作る想定。

### 根本原因

ghalint policy 010（`github_app_should_limit_permissions`）に従いトークンを `permission-*` で **contents / pull-requests / issues に絞り込んでいた**ため `vulnerability_alerts` が欠け、Renovate が脆弱性アラート API で 403 を受けていた。

確認済み（GitHub Docs / create-github-app-token README）:
- `vulnerability_alerts` はインストールトークンの正規キー（read/write、"manage Dependabot alerts"）
- 入力名は `permission-vulnerability-alerts`
- `permission-*` 指定でトークンは絞り込まれる
- App が持たない権限を要求するとトークン発行が **422** で失敗

## 変更内容

`.github/workflows/renovate.yaml` の `create-github-app-token` に1行追加:
```yaml
permission-vulnerability-alerts: read
```
ghalint の「権限を明示列挙」方針のまま、必要権限を1つ足すだけ。

## ⚠️ マージ前の前提（手動・順序重要）

このコードを適用する前に **GitHub App 側に「Dependabot alerts: Read-only」を付与し、インストールで承認**しておくこと。未付与のままだとトークン発行ステップが 422 で失敗し Renovate が完全停止する。

1. App → Permissions → Repository → **Dependabot alerts: Read-only** を追加・保存
2. Settings → Applications →（App）→ "Review request" で新権限を承認
3. Settings → Code security → **Dependabot alerts が有効**であることを確認

## 検証（マージ後）

`gh workflow run renovate.yaml -f logLevel=debug` → ログに `Cannot access vulnerability alerts` が出ないこと・トークン発行が 422 しないこと・Dashboard の WARN が消えることを確認。

## 検証済み（ローカル）

- `actionlint`: OK
- `ghalint run`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)