### PR TITLE
ci(renovate): use client-id for App token (app-id deprecated in v3)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -53,7 +53,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          # app-id は v3 で非推奨。Client ID（App ID とは別値の Iv23li... 形式）を使う。
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # 生成トークンを最小権限に限定（metadata:read は常時付与）。
           #   contents            : ブランチ・コミット・lockfile 更新


### PR DESCRIPTION
## なぜ

`actions/create-github-app-token` v3 で `app-id` 入力が非推奨になり、Renovate 実行時に
`Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.`
が出ていた。

## 変更内容

`.github/workflows/renovate.yaml` の token 発行を `app-id` → **`client-id`** に切替:
```yaml
client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
```
`client-id` は **App ID（数値）とは別値**の Client ID 文字列（`Iv23li...` 形式）。

## ⚠️ マージ前の前提（手動・順序重要）

このコードを実行する前に、GitHub App 設定ページの **"Client ID"** を secret
`RENOVATE_CLIENT_ID` に登録すること。未登録だと `client-id` が空になりトークン発行が失敗する。

```bash
gh secret set RENOVATE_CLIENT_ID --body "<App の Client ID（Iv23li... 形式）>"
```

切替確認後、旧 `RENOVATE_APP_ID` secret は削除してよい（`gh secret delete RENOVATE_APP_ID`）。

## 検証（マージ後）

`gh workflow run renovate.yaml -f logLevel=debug` → `app-id ... deprecated` 警告が出ないこと・
トークン発行が成功すること（client-id 空エラーが出ないこと）を確認。

## 検証済み（ローカル）

- `actionlint`: OK
- `ghalint run`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)