### PR TITLE
ci(renovate): surface checkbox handling for issues-triggered runs

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -84,9 +84,16 @@ jobs:
           # 十分なメモリ(16GB)を持つので Renovate プロセス自身のヒープに 6GB 割り当てる。
           # pnpm 子プロセス側の上限は renovate.json5 の toolSettings.nodeMaxMemory(4096) が担保。
           NODE_OPTIONS: --max-old-space-size=6144
-          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-          # dryRun=true のとき 'full'、それ以外（schedule 実行含む）は空＝通常実行。
+          # issues(Dependency Dashboard のチェックボックス)起動時は per-branch のスキップ理由
+          # (unschedule-branch= / minimumReleaseAge / internalChecksFilter 等)を可視化するため
+          # debug に上げる。checkbox を toggle しても PR が作られない事象の切り分けに必須。
+          # workflow_dispatch では入力の logLevel を尊重、それ以外(schedule)は info。
+          LOG_LEVEL: ${{ inputs.logLevel || (github.event_name == 'issues' && 'debug' || 'info') }}
+          # dryRun=true のとき 'full'、それ以外は空＝通常実行。
           RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}
-          # schedule trigger 以外（workflow_dispatch）はユーザの能動的なアクションなので、
-          # renovate.json5 の schedule を無視して即時実行する（force で schedule を空に上書き）。
-          RENOVATE_FORCE: ${{ github.event_name != 'schedule' && '{"schedule":[]}' || '' }}
+          # workflow_dispatch だけ schedule を無視して即時実行する（force で schedule を空に上書き）。
+          # issues 起動では force を付けない: force で schedule を全体平坦化すると run が「schedule
+          # 無視の full run」になり、checkbox 由来の per-branch 判断(unschedule override が schedule を
+          # 解除できているか)が観測できなくなるため。checkbox の unschedule/unlimit セマンティクスに委ねる。
+          # 注: checkbox(unschedule)は schedule のみ bypass し minimumReleaseAge は解除しない。
+          RENOVATE_FORCE: ${{ github.event_name == 'workflow_dispatch' && '{"schedule":[]}' || '' }}


### PR DESCRIPTION
Dependency Dashboard のチェックボックスを toggle しても PR が作られない事象を
診断可能にする。トリガーと if フィルタは正常(run は success)だが Renovate ステップが
no-op で終わる。原因切り分けには per-branch のスキップ理由が必要だが過去 run は
LOG_LEVEL=info で出ていなかった。

- issues 起動時のみ LOG_LEVEL=debug に上書き。unschedule-branch= /
  minimumReleaseAge / internalChecksFilter 等の per-branch 判断を可視化する。
- issues 起動では RENOVATE_FORCE を外し workflow_dispatch 限定に変更。force で
  schedule を全体平坦化すると checkbox 由来の per-branch 判断が観測できなくなるため、
  checkbox の unschedule/unlimit セマンティクスに委ねる。
- 「既存 force が checkbox 起動を即時化する」という誤前提のコメントを訂正
  (checkbox の unschedule は schedule のみ bypass し minimumReleaseAge は解除しない)。

注: issues トリガーは default branch の workflow 定義で発火するため、確定診断は
main 反映後に dashboard のチェックボックスを toggle して debug ログを確認する。

https://claude.ai/code/session_01DLhRuEDFV4rynxukxidJFK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions の Renovate ワークフロー設定を最適化しました。ログレベルと実行オプションの条件制御が改善され、異なる起動方法に応じた適切な設定が行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->