### PR TITLE
ci(renovate): grant App token statuses:write (was missing from merged #2362)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -60,12 +60,18 @@ jobs:
           #   contents            : ブランチ・コミット・lockfile 更新
           #   pull-requests       : PR 作成・automerge 有効化
           #   issues              : Dependency Dashboard issue の維持
+          #   statuses            : minimumReleaseAge の内部チェックを renovate/stability-days という
+          #     commit status として branch に書き込む。無いと POST /statuses が 403
+          #     "Resource not accessible by integration" → Renovate が integration-unauthorized を
+          #     repository-changed に変換し run 全体を中断、以降の PR が一切作られない。
+          #     （App 側にも "Commit statuses: Read and write" の付与が必要。無いとトークン発行が 422）。
           #   vulnerability-alerts: Dependabot alerts を読み security ラベル付き脆弱性 PR を作る
           #     （renovate.json5 の vulnerabilityAlerts / :enableVulnerabilityAlertsWithLabel の前提。
           #      App 側にも "Dependabot alerts: Read" の付与が必要。無いとトークン発行が 422）。
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-statuses: write
           permission-vulnerability-alerts: read
 
       # self-host 実行。repo 設定 .github/renovate.json5 は Renovate が自動検出する


### PR DESCRIPTION
## 概要

Renovate の PR が（security 1件以外）作られない問題の**最終修正**。`create-github-app-token` に **`permission-statuses: write`** を追加する。

> ⚠️ 前回の PR #2362 はこの修正コミット (`8f67a9e`) を**含まない状態 (`b267dc5`) でマージ**されてしまったため、main に `statuses:write` が入っておらず事象が継続していた。本PRで改めて main に入れる。

## 真因（debug run `27007073844` で再確認）

Renovate は `minimumReleaseAge` の内部チェックを `renovate/stability-days` という **commit status** として branch に書き込む。App トークンに `statuses:write` が無いため:

```
POST /repos/.../statuses/{sha} → 403 "Resource not accessible by integration"
x-accepted-github-permissions: statuses=write
→ Renovate が integration-unauthorized を repository-changed に変換 → run 全体を中断
```

最初の非 security branch（postcss）でこの 403 → 中断 → 以降の PR が一切作られない。security PR #2361 だけ成功したのは minimumReleaseAge を bypass し status を書かないため。

## 変更

`.github/workflows/renovate.yaml` の token 発行に `permission-statuses: write` を追加（対象1ファイル）。

## ⚠️ 必須の前提（未付与だとトークン発行が 422 で全 run 失敗）

> GitHub App 設定 → Permissions → **「Commit statuses: Read and write」を付与 → インストールで承認**

（Dependabot alerts のときと同じ「App 側にも権限付与が必要」パターン。**この付与が無いと逆に全 run が 422 で落ちる**ので、マージ前に必ず付与してください。）

## 検証

付与＋マージ後、workflow_dispatch を1回起動 → 私が debug ログで「`renovate/stability-days` status が 201 で書け、`repository-changed` 中断が消え、残りの PR が作成され `result: "done"` で完走」することを確認する。

https://claude.ai/code/session_01DLhRuEDFV4rynxukxidJFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLhRuEDFV4rynxukxidJFK)_