### PR TITLE
feat: introduce nonce-based Content Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,7 @@ This document outlines the security practices and policies for this project.
 - [npm/pnpm Security Configuration](#npmpnpm-security-configuration)
 - [CI/CD Security](#cicd-security)
 - [Security Auditing](#security-auditing)
+- [Content Security Policy](#content-security-policy)
 - [Application Security Scanning (Aikido)](#application-security-scanning-aikido)
 - [Supply Chain Attack Prevention](#supply-chain-attack-prevention)
 
@@ -212,6 +213,37 @@ pnpm i --frozen-lockfile
 2. **Before release**: Run `pnpm security` manually
 3. **After security announcements**: Run `pnpm security:fix` and `pnpm security:report`
 
+## Content Security Policy
+
+The application uses a request-scoped nonce generated in `app/src/proxy.ts`.
+The nonce is forwarded to server rendering through the internal `x-nonce`
+header and an upstream `Content-Security-Policy` request header. Browser
+responses currently receive `Content-Security-Policy-Report-Only` while the
+policy is being validated.
+
+### Policy
+
+- `script-src` permits self, the request nonce, Vercel Analytics, development-only React Scan, and Preview-only Vercel Toolbar.
+- Production does not allow `unsafe-inline` or `unsafe-eval` for scripts.
+- Production `style-src-elem` requires self or the request nonce.
+- `style-src-attr 'unsafe-inline'` remains enabled because UI positioning and syntax highlighting use dynamic style attributes.
+- Preview deployments allow the additional script, connection, image, frame, style, and font sources documented for Vercel Toolbar.
+- CSP violations are reported to the configured Sentry reporting endpoint through `report-uri` and `Report-To`.
+
+### Enforcement rollout
+
+Before replacing `Content-Security-Policy-Report-Only` with
+`Content-Security-Policy`:
+
+1. Exercise authentication, locale navigation, theme switching, Toast, Dialog, Drawer, Lightbox, and Markdown code rendering in Preview.
+2. Confirm that Sentry contains no unexplained violations from supported browsers.
+3. Verify production Report-Only telemetry separately because Preview intentionally has a broader Toolbar policy.
+4. Change only the response header name in Proxy; keep the upstream request header enforced so Next.js continues to attach nonces during SSR.
+
+Cache Components / PPR are intentionally disabled because their reusable static
+HTML shell cannot carry a fresh nonce for every request. Database query results
+remain cached with tenant-scoped `unstable_cache` keys and tags.
+
 ## Application Security Scanning (Aikido)
 
 This project uses [Aikido Security](https://www.aikido.dev/) (Forever Free plan) for
@@ -364,6 +396,6 @@ pnpm security
 
 ---
 
-**Last Updated**: 2026-06-03
+**Last Updated**: 2026-06-06
 
 For questions about this security policy, contact s-hirano-ist@outlook.com.

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -4,31 +4,8 @@ import { withSentryConfig } from "@sentry/nextjs";
 // await import("./src/env.ts");
 import createNextIntlPlugin from "next-intl/plugin";
 
-// MEMO: scriptタグを利用する必要が出たときはnonceの利用推奨
-// https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy#reading-the-nonce
-
 // MEMO: その他のheadersについては下記参照
 // https://nextjs.org/docs/pages/api-reference/next-config-js/headers
-
-// MEMO: worker-src 'self' blob:; for Sentry
-
-const cspHeader = `
-    default-src 'self' https://vercel.live;
-	connect-src 'self';
-	script-src 'self' 'unsafe-eval' 'unsafe-inline' https://unpkg.com https://va.vercel-scripts.com https://vercel.live;
-    style-src 'self' 'unsafe-inline';
-	img-src 'self' blob: data: https://${process.env.MINIO_HOST}:${process.env.MINIO_PORT ?? "443"};
-    font-src 'self';
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors 'none';
-	worker-src 'self' blob:;
-	manifest-src 'self' ${process.env.AUTH0_ISSUER_BASE_URL};
-    upgrade-insecure-requests;
-	report-uri ${process.env.SENTRY_REPORT_URL};
-    report-to csp-endpoint;
-	`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -41,7 +18,6 @@ const nextConfig = {
 	serverExternalPackages: ["sharp", "@prisma/client"],
 	typedRoutes: true,
 	reactCompiler: true,
-	cacheComponents: true, // v16: moved from experimental.useCache
 	experimental: {
 		authInterrupts: true,
 		staleTimes: {
@@ -95,10 +71,6 @@ const nextConfig = {
 					// 	key: "Cache-Control",
 					// 	value: "private, no-store, must-revalidate",
 					// },
-					{
-						key: "Content-Security-Policy",
-						value: cspHeader.replaceAll("\n", ""),
-					},
 					{
 						key: "Report-To",
 						value: `{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"${process.env.SENTRY_REPORT_URL}"}],"include_subdomains":true}`,

--- a/app/src/app/[locale]/layout.tsx
+++ b/app/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@s-hirano-ist/s-ui/providers/theme-provider";
 import { Toaster } from "@s-hirano-ist/s-ui/ui/sonner";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { type ReactNode, Suspense } from "react";
 
@@ -24,6 +25,7 @@ async function LocaleLayoutContent({ children, params }: Params) {
 	}
 
 	const messages = await getMessages();
+	const nonce = (await headers()).get("x-nonce") ?? undefined;
 
 	return (
 		<NextIntlClientProvider messages={messages}>
@@ -32,6 +34,7 @@ async function LocaleLayoutContent({ children, params }: Params) {
 				defaultTheme="system"
 				disableTransitionOnChange
 				enableSystem
+				nonce={nonce}
 			>
 				<main className="min-h-screen">
 					<div className="pb-24">{children}</div>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { env } from "@/env";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Noto_Sans_JP } from "next/font/google";
+import { headers } from "next/headers";
 
 const notoSansJp = Noto_Sans_JP({ subsets: ["latin"], display: "swap" });
 
@@ -26,9 +27,11 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{ children: ReactNode }>) {
+	const nonce = (await headers()).get("x-nonce") ?? undefined;
+
 	return (
 		<html lang="ja" suppressHydrationWarning>
 			{/*https://github.com/pacocoursey/next-themes*/}
@@ -37,6 +40,7 @@ export default function RootLayout({
 				{env.NODE_ENV === "development" && (
 					<script
 						async
+						nonce={nonce}
 						src="https://unpkg.com/react-scan/dist/auto.global.js"
 					/>
 				)}

--- a/app/src/application-services/articles/get-articles.ts
+++ b/app/src/application-services/articles/get-articles.ts
@@ -33,7 +33,7 @@ import {
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { SystemErrorEvent } from "@s-hirano-ist/s-core/shared-kernel/events/system-error-event";
-import { cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 /**
@@ -49,9 +49,11 @@ const getArticlesCountCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<number> => {
-	"use cache";
-	cacheTag(buildCountCacheTag("articles", status, userId));
-	return await articlesQueryRepository.count(userId, status);
+	return unstable_cache(
+		() => articlesQueryRepository.count(userId, status),
+		["articles", "count", userId, status],
+		{ tags: [buildCountCacheTag("articles", status, userId)] },
+	)();
 };
 
 /**
@@ -69,38 +71,44 @@ const getArticlesCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<LinkCardStackInitialData> => {
-	"use cache";
-	cacheTag(
-		buildContentCacheTag("articles", status, userId),
-		buildPaginatedContentCacheTag("articles", status, userId, currentCount),
-	);
-	const [articles, totalCount] = await Promise.all([
-		articlesQueryRepository.findMany(userId, status, {
-			skip: currentCount,
-			take: PAGE_SIZE,
-			orderBy: { createdAt: "desc" },
-		}),
-		getArticlesCountCached(userId, status),
-	]);
+	return unstable_cache(
+		async () => {
+			const [articles, totalCount] = await Promise.all([
+				articlesQueryRepository.findMany(userId, status, {
+					skip: currentCount,
+					take: PAGE_SIZE,
+					orderBy: { createdAt: "desc" },
+				}),
+				getArticlesCountCached(userId, status),
+			]);
 
-	return {
-		data: articles.map((d) => {
-			const description = `${d.quote ? `${d.quote}\n` : ""}${d.ogTitle ? `${d.ogTitle}\n` : ""}${d.ogDescription ? d.ogDescription : ""}`;
 			return {
-				id: d.id,
-				primaryBadgeText: d.categoryName,
-				secondaryBadgeText: new URL(d.url).hostname,
-				key: d.id,
-				title: d.title,
-				description:
-					description.length > 200
-						? `${description.slice(0, 200)}...`
-						: description,
-				href: d.url,
+				data: articles.map((d) => {
+					const description = `${d.quote ? `${d.quote}\n` : ""}${d.ogTitle ? `${d.ogTitle}\n` : ""}${d.ogDescription ? d.ogDescription : ""}`;
+					return {
+						id: d.id,
+						primaryBadgeText: d.categoryName,
+						secondaryBadgeText: new URL(d.url).hostname,
+						key: d.id,
+						title: d.title,
+						description:
+							description.length > 200
+								? `${description.slice(0, 200)}...`
+								: description,
+						href: d.url,
+					};
+				}),
+				totalCount,
 			};
-		}),
-		totalCount,
-	};
+		},
+		["articles", "list", userId, status, String(currentCount)],
+		{
+			tags: [
+				buildContentCacheTag("articles", status, userId),
+				buildPaginatedContentCacheTag("articles", status, userId, currentCount),
+			],
+		},
+	)();
 };
 
 /**
@@ -114,26 +122,30 @@ const getArticlesCached = async (
 const getCategoriesCached = async (
 	userId: UserId,
 ): Promise<ArticleFormData> => {
-	"use cache";
-	cacheTag("categories", buildCategoriesCacheTag(userId));
-	try {
-		const response = await categoryQueryRepository.findMany(userId, {
-			orderBy: { name: "asc" },
-		});
-		return response;
-	} catch (error) {
-		initializeEventHandlers();
-		await eventDispatcher.dispatch(
-			new SystemErrorEvent({
-				message: "unexpected",
-				status: 500,
-				caller: "AddArticleFormCategory",
-				extraData: error,
-			}),
-		);
-		// not critical for viewer nor dumper
-		return [];
-	}
+	return unstable_cache(
+		async () => {
+			try {
+				const response = await categoryQueryRepository.findMany(userId, {
+					orderBy: { name: "asc" },
+				});
+				return response;
+			} catch (error) {
+				initializeEventHandlers();
+				await eventDispatcher.dispatch(
+					new SystemErrorEvent({
+						message: "unexpected",
+						status: 500,
+						caller: "AddArticleFormCategory",
+						extraData: error,
+					}),
+				);
+				// not critical for viewer nor dumper
+				return [];
+			}
+		},
+		["articles", "categories", userId],
+		{ tags: ["categories", buildCategoriesCacheTag(userId)] },
+	)();
 };
 
 /**

--- a/app/src/application-services/books/get-books.ts
+++ b/app/src/application-services/books/get-books.ts
@@ -27,7 +27,7 @@ import {
 	type Status,
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
-import { cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 const API_BOOK_THUMBNAIL_PATH = "/api/books/images/thumbnail";
@@ -41,9 +41,11 @@ const getBooksCountCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<number> => {
-	"use cache";
-	cacheTag(buildCountCacheTag("books", status, userId));
-	return await booksQueryRepository.count(userId, status);
+	return unstable_cache(
+		() => booksQueryRepository.count(userId, status),
+		["books", "count", userId, status],
+		{ tags: [buildCountCacheTag("books", status, userId)] },
+	)();
 };
 
 /**
@@ -56,36 +58,41 @@ const getBooksCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<ImageCardStackInitialData> => {
-	"use cache";
-	cacheTag(
-		buildContentCacheTag("books", status, userId),
-		buildPaginatedContentCacheTag("books", status, userId, currentCount),
-	);
+	return unstable_cache(
+		async () => {
+			const [books, totalCount] = await Promise.all([
+				booksQueryRepository.findMany(userId, status, {
+					skip: currentCount,
+					take: PAGE_SIZE,
+					orderBy: { createdAt: "desc" },
+				}),
+				getBooksCountCached(userId, status),
+			]);
 
-	const [books, totalCount] = await Promise.all([
-		booksQueryRepository.findMany(userId, status, {
-			skip: currentCount,
-			take: PAGE_SIZE,
-			orderBy: { createdAt: "desc" },
-		}),
-		getBooksCountCached(userId, status),
-	]);
-
-	return {
-		data: books.map((d) => ({
-			id: d.id,
-			title: d.title,
-			href: d.isbn,
-			image: d.imagePath
-				? `${API_BOOK_THUMBNAIL_PATH}/${d.imagePath}`
-				: (d.googleImgSrc ?? null),
-			subtitle: d.googleSubTitle ? String(d.googleSubTitle) : undefined,
-			authors: d.googleAuthors
-				? (d.googleAuthors as unknown as string[]).join(", ")
-				: undefined,
-		})),
-		totalCount,
-	};
+			return {
+				data: books.map((d) => ({
+					id: d.id,
+					title: d.title,
+					href: d.isbn,
+					image: d.imagePath
+						? `${API_BOOK_THUMBNAIL_PATH}/${d.imagePath}`
+						: (d.googleImgSrc ?? null),
+					subtitle: d.googleSubTitle ? String(d.googleSubTitle) : undefined,
+					authors: d.googleAuthors
+						? (d.googleAuthors as unknown as string[]).join(", ")
+						: undefined,
+				})),
+				totalCount,
+			};
+		},
+		["books", "list", userId, status, String(currentCount)],
+		{
+			tags: [
+				buildContentCacheTag("books", status, userId),
+				buildPaginatedContentCacheTag("books", status, userId, currentCount),
+			],
+		},
+	)();
 };
 
 /**

--- a/app/src/application-services/cache-configuration.test.ts
+++ b/app/src/application-services/cache-configuration.test.ts
@@ -1,0 +1,105 @@
+import { unstable_cache } from "next/cache";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getExportedArticles } from "./articles/get-articles";
+import { getUnexportedBooks } from "./books/get-books";
+import { getExportedImages } from "./images/get-images";
+import { getUnexportedNotes } from "./notes/get-notes";
+
+vi.mock("@/common/auth/session", () => ({
+	getSelfId: vi.fn().mockResolvedValue("tenant-a"),
+}));
+
+vi.mock(
+	"@/infrastructures/articles/repositories/articles-query-repository",
+	() => ({
+		articlesQueryRepository: {
+			findMany: vi.fn().mockResolvedValue([]),
+			count: vi.fn().mockResolvedValue(0),
+		},
+		categoryQueryRepository: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
+	}),
+);
+
+vi.mock("@/infrastructures/books/repositories/books-query-repository", () => ({
+	booksQueryRepository: {
+		findMany: vi.fn().mockResolvedValue([]),
+		count: vi.fn().mockResolvedValue(0),
+	},
+}));
+
+vi.mock(
+	"@/infrastructures/images/repositories/images-query-repository",
+	() => ({
+		imagesQueryRepository: {
+			findMany: vi.fn().mockResolvedValue([]),
+			count: vi.fn().mockResolvedValue(0),
+		},
+	}),
+);
+
+vi.mock("@/infrastructures/notes/repositories/notes-query-repository", () => ({
+	notesQueryRepository: {
+		findMany: vi.fn().mockResolvedValue([]),
+		count: vi.fn().mockResolvedValue(0),
+	},
+}));
+
+describe("query cache configuration", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("keys list caches by domain, tenant, status, and page", async () => {
+		await getExportedArticles(48);
+		await getUnexportedBooks(24);
+		await getExportedImages(3);
+		await getUnexportedNotes(72);
+
+		const keyParts = vi
+			.mocked(unstable_cache)
+			.mock.calls.map(([, keys]) => keys);
+
+		expect(keyParts).toContainEqual([
+			"articles",
+			"list",
+			"tenant-a",
+			"EXPORTED",
+			"48",
+		]);
+		expect(keyParts).toContainEqual([
+			"books",
+			"list",
+			"tenant-a",
+			"UNEXPORTED",
+			"24",
+		]);
+		expect(keyParts).toContainEqual([
+			"images",
+			"list",
+			"tenant-a",
+			"EXPORTED",
+			"3",
+		]);
+		expect(keyParts).toContainEqual([
+			"notes",
+			"list",
+			"tenant-a",
+			"UNEXPORTED",
+			"72",
+		]);
+	});
+
+	test("preserves tenant-scoped invalidation tags", async () => {
+		await getExportedArticles(0);
+
+		const listCall = vi
+			.mocked(unstable_cache)
+			.mock.calls.find(([, keys]) => keys?.[1] === "list");
+
+		expect(listCall?.[2]).toEqual({
+			tags: ["articles_EXPORTED_tenanta", "articles_EXPORTED_tenanta_0"],
+		});
+	});
+});

--- a/app/src/application-services/images/get-images.ts
+++ b/app/src/application-services/images/get-images.ts
@@ -25,7 +25,7 @@ import {
 	type Status,
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
-import { cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 /** API path for original images */
@@ -42,9 +42,11 @@ const getImagesCountCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<number> => {
-	"use cache";
-	cacheTag(buildCountCacheTag("images", status, userId));
-	return await imagesQueryRepository.count(userId, status);
+	return unstable_cache(
+		() => imagesQueryRepository.count(userId, status),
+		["images", "count", userId, status],
+		{ tags: [buildCountCacheTag("images", status, userId)] },
+	)();
 };
 
 /**
@@ -57,26 +59,32 @@ const getImagesCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<ImageData[]> => {
-	"use cache";
-	cacheTag(
-		buildContentCacheTag("images", status, userId),
-		buildPaginatedContentCacheTag("images", status, userId, page),
-	);
-	const data = await imagesQueryRepository.findMany(userId, status, {
-		skip: (page - 1) * PAGE_SIZE,
-		take: PAGE_SIZE,
-		orderBy: { createdAt: "desc" },
-	});
+	return unstable_cache(
+		async () => {
+			const data = await imagesQueryRepository.findMany(userId, status, {
+				skip: (page - 1) * PAGE_SIZE,
+				take: PAGE_SIZE,
+				orderBy: { createdAt: "desc" },
+			});
 
-	return data.map((d) => {
-		return {
-			id: d.id,
-			originalPath: `${API_ORIGINAL_PATH}/${d.path}`,
-			thumbnailPath: `${API_THUMBNAIL_PATH}/${d.path}`,
-			height: d.height,
-			width: d.width,
-		};
-	});
+			return data.map((d) => {
+				return {
+					id: d.id,
+					originalPath: `${API_ORIGINAL_PATH}/${d.path}`,
+					thumbnailPath: `${API_THUMBNAIL_PATH}/${d.path}`,
+					height: d.height,
+					width: d.width,
+				};
+			});
+		},
+		["images", "list", userId, status, String(page)],
+		{
+			tags: [
+				buildContentCacheTag("images", status, userId),
+				buildPaginatedContentCacheTag("images", status, userId, page),
+			],
+		},
+	)();
 };
 
 /**

--- a/app/src/application-services/notes/get-notes.ts
+++ b/app/src/application-services/notes/get-notes.ts
@@ -26,7 +26,7 @@ import {
 	type Status,
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
-import { cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 /**
@@ -38,9 +38,11 @@ const getNotesCountCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<number> => {
-	"use cache";
-	cacheTag(buildCountCacheTag("notes", status, userId));
-	return await notesQueryRepository.count(userId, status);
+	return unstable_cache(
+		() => notesQueryRepository.count(userId, status),
+		["notes", "count", userId, status],
+		{ tags: [buildCountCacheTag("notes", status, userId)] },
+	)();
 };
 
 /**
@@ -58,43 +60,51 @@ const getNotesCached = async (
 	userId: UserId,
 	status: Status,
 ): Promise<LinkCardStackInitialData> => {
-	"use cache";
-	cacheTag(
-		buildContentCacheTag("notes", status, userId),
-		buildPaginatedContentCacheTag("notes", status, userId, currentCount),
-	);
-	const [notes, totalCount] = await Promise.all([
-		notesQueryRepository.findMany(userId, status, {
-			skip: currentCount,
-			take: PAGE_SIZE,
-			orderBy: { createdAt: "desc" },
-		}),
-		getNotesCountCached(userId, status),
-	]);
-
-	return {
-		data: notes.map((d) => {
-			const plainText = String(d.markdown)
-				.replaceAll(/^#{1,6}\s+/gmu, "")
-				.replaceAll(/[*_~`]/gu, "")
-				.replaceAll(/\[([^\]]*)\]\([^)]*\)/gu, "$1")
-				.replaceAll(/!\[([^\]]*)\]\([^)]*\)/gu, "$1")
-				.replaceAll(/\n+/gu, " ")
-				.trim();
-			const description =
-				plainText.length > 150 ? `${plainText.slice(0, 150)}...` : plainText;
+	return unstable_cache(
+		async () => {
+			const [notes, totalCount] = await Promise.all([
+				notesQueryRepository.findMany(userId, status, {
+					skip: currentCount,
+					take: PAGE_SIZE,
+					orderBy: { createdAt: "desc" },
+				}),
+				getNotesCountCached(userId, status),
+			]);
 
 			return {
-				id: d.id,
-				key: d.id,
-				title: d.title,
-				description,
-				primaryBadgeText: new Date(d.createdAt).toLocaleDateString("ja-JP"),
-				href: `/note/${encodeURIComponent(d.title)}`,
+				data: notes.map((d) => {
+					const plainText = String(d.markdown)
+						.replaceAll(/^#{1,6}\s+/gmu, "")
+						.replaceAll(/[*_~`]/gu, "")
+						.replaceAll(/\[([^\]]*)\]\([^)]*\)/gu, "$1")
+						.replaceAll(/!\[([^\]]*)\]\([^)]*\)/gu, "$1")
+						.replaceAll(/\n+/gu, " ")
+						.trim();
+					const description =
+						plainText.length > 150
+							? `${plainText.slice(0, 150)}...`
+							: plainText;
+
+					return {
+						id: d.id,
+						key: d.id,
+						title: d.title,
+						description,
+						primaryBadgeText: new Date(d.createdAt).toLocaleDateString("ja-JP"),
+						href: `/note/${encodeURIComponent(d.title)}`,
+					};
+				}),
+				totalCount,
 			};
-		}),
-		totalCount,
-	};
+		},
+		["notes", "list", userId, status, String(currentCount)],
+		{
+			tags: [
+				buildContentCacheTag("notes", status, userId),
+				buildPaginatedContentCacheTag("notes", status, userId, currentCount),
+			],
+		},
+	)();
 };
 
 /**

--- a/app/src/common/tenant/tenant-filter.ts
+++ b/app/src/common/tenant/tenant-filter.ts
@@ -13,9 +13,9 @@
  * - **Reads** (`findMany` / `findFirst` / `count` / `aggregate` / `groupBy`):
  *   fail-open. When a scope is present `userId` is AND-ed into `where`; when it
  *   is absent the query passes through unchanged (the repositories' explicit
- *   `where: { userId }` still isolates tenants). Reads can run inside the Next.js
- *   `"use cache"` boundary where AsyncLocalStorage may not propagate, so failing
- *   closed here would break cached reads.
+ *   `where: { userId }` still isolates tenants). Reads can run inside a Next.js
+ *   `unstable_cache` callback where AsyncLocalStorage may not propagate, so
+ *   failing closed here would break cached reads.
  * - **Mutations** (`create` / `update` / `delete` / `*Many` / `upsert`):
  *   fail-closed. A missing scope throws, refusing to run a write with no tenant
  *   isolation. Mutations always run on the (non-cached) server-action path where

--- a/app/src/infrastructures/security/content-security-policy.test.ts
+++ b/app/src/infrastructures/security/content-security-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { buildContentSecurityPolicy } from "./content-security-policy";
+
+const BASE_OPTIONS = {
+	nonce: "test-nonce",
+	minioHost: "minio.example.com",
+	minioPort: "443",
+	reportUrl: "https://sentry.example.com/csp",
+};
+
+describe("buildContentSecurityPolicy", () => {
+	test("builds a strict production policy", () => {
+		const policy = buildContentSecurityPolicy({
+			...BASE_OPTIONS,
+			isDevelopment: false,
+			isPreview: false,
+		});
+
+		expect(policy).toContain("script-src 'self' 'nonce-test-nonce'");
+		expect(policy).not.toMatch(/script-src[^;]*'unsafe-inline'/u);
+		expect(policy).not.toMatch(/script-src[^;]*'unsafe-eval'/u);
+		expect(policy).toContain("style-src-elem 'self' 'nonce-test-nonce'");
+		expect(policy).not.toMatch(/style-src-elem[^;]*'unsafe-inline'/u);
+		expect(policy).toContain("style-src-attr 'unsafe-inline'");
+		expect(policy).toContain(
+			"img-src 'self' blob: data: https://books.google.com https://s-hirano.com https://minio.example.com",
+		);
+		expect(policy).toContain("upgrade-insecure-requests");
+		expect(policy).toContain("report-uri https://sentry.example.com/csp");
+	});
+
+	test("adds only the documented Vercel Toolbar sources in preview", () => {
+		const policy = buildContentSecurityPolicy({
+			...BASE_OPTIONS,
+			isDevelopment: false,
+			isPreview: true,
+		});
+
+		expect(policy).toMatch(/script-src[^;]*https:\/\/vercel\.live/u);
+		expect(policy).toMatch(
+			/connect-src[^;]*https:\/\/vercel\.live[^;]*wss:\/\/ws-us3\.pusher\.com/u,
+		);
+		expect(policy).toMatch(/style-src-elem[^;]*'unsafe-inline'/u);
+		expect(policy).not.toMatch(/style-src-elem[^;]*'nonce-/u);
+		expect(policy).toContain("frame-src https://vercel.live");
+		expect(policy).toMatch(/font-src[^;]*https:\/\/assets\.vercel\.com/u);
+	});
+
+	test("allows development tooling without upgrading localhost requests", () => {
+		const policy = buildContentSecurityPolicy({
+			...BASE_OPTIONS,
+			isDevelopment: true,
+			isPreview: false,
+		});
+
+		expect(policy).toMatch(/script-src[^;]*'unsafe-eval'/u);
+		expect(policy).toMatch(/script-src[^;]*https:\/\/unpkg\.com/u);
+		expect(policy).toMatch(/style-src-elem[^;]*'unsafe-inline'/u);
+		expect(policy).toMatch(/connect-src[^;]*ws:/u);
+		expect(policy).not.toContain("upgrade-insecure-requests");
+	});
+});

--- a/app/src/infrastructures/security/content-security-policy.ts
+++ b/app/src/infrastructures/security/content-security-policy.ts
@@ -1,0 +1,94 @@
+const CSP_REPORTING_GROUP = "csp-endpoint";
+
+type ContentSecurityPolicyOptions = {
+	isDevelopment: boolean;
+	isPreview: boolean;
+	minioHost?: string;
+	minioPort?: string;
+	nonce: string;
+	reportUrl?: string;
+};
+
+function compactDirectives(directives: string[]): string {
+	return directives.join("; ");
+}
+
+function getMinioOrigin(host?: string, port?: string): string | undefined {
+	if (!host) return undefined;
+
+	const normalizedPort = port && port !== "443" ? `:${port}` : "";
+	return `https://${host}${normalizedPort}`;
+}
+
+export function buildContentSecurityPolicy({
+	isDevelopment,
+	isPreview,
+	minioHost,
+	minioPort,
+	nonce,
+	reportUrl,
+}: ContentSecurityPolicyOptions): string {
+	const allowsVercelToolbar = isPreview;
+	const allowsInlineStyleElements = isDevelopment || allowsVercelToolbar;
+	const minioOrigin = getMinioOrigin(minioHost, minioPort);
+
+	const scriptSources = [
+		"'self'",
+		`'nonce-${nonce}'`,
+		...(isDevelopment ? ["'unsafe-eval'", "https://unpkg.com"] : []),
+		"https://va.vercel-scripts.com",
+		...(allowsVercelToolbar ? ["https://vercel.live"] : []),
+	];
+	const styleElementSources = allowsInlineStyleElements
+		? [
+				"'self'",
+				"'unsafe-inline'",
+				...(allowsVercelToolbar ? ["https://vercel.live"] : []),
+			]
+		: ["'self'", `'nonce-${nonce}'`];
+	const imageSources = [
+		"'self'",
+		"blob:",
+		"data:",
+		"https://books.google.com",
+		"https://s-hirano.com",
+		...(minioOrigin ? [minioOrigin] : []),
+		...(allowsVercelToolbar
+			? ["https://vercel.live", "https://vercel.com"]
+			: []),
+	];
+	const connectSources = [
+		"'self'",
+		...(isDevelopment ? ["ws:", "wss:"] : []),
+		...(allowsVercelToolbar
+			? ["https://vercel.live", "wss://ws-us3.pusher.com"]
+			: []),
+	];
+	const fontSources = [
+		"'self'",
+		...(allowsVercelToolbar
+			? ["https://vercel.live", "https://assets.vercel.com"]
+			: []),
+	];
+
+	return compactDirectives([
+		"default-src 'self'",
+		`script-src ${scriptSources.join(" ")}`,
+		`style-src ${styleElementSources.join(" ")}`,
+		`style-src-elem ${styleElementSources.join(" ")}`,
+		"style-src-attr 'unsafe-inline'",
+		`img-src ${imageSources.join(" ")}`,
+		`connect-src ${connectSources.join(" ")}`,
+		`font-src ${fontSources.join(" ")}`,
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+		"frame-ancestors 'none'",
+		...(allowsVercelToolbar ? ["frame-src https://vercel.live"] : []),
+		"worker-src 'self' blob:",
+		"manifest-src 'self'",
+		...(isDevelopment ? [] : ["upgrade-insecure-requests"]),
+		...(reportUrl ? [`report-uri ${reportUrl}`] : []),
+		`report-to ${CSP_REPORTING_GROUP}`,
+	]);
+}

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -1,0 +1,107 @@
+import { getSessionCookie } from "better-auth/cookies";
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import proxy, { config } from "./proxy";
+
+const capturedRequests = vi.hoisted(() => [] as NextRequest[]);
+
+vi.unmock("next/server");
+
+vi.mock("better-auth/cookies", () => ({
+	getSessionCookie: vi.fn(),
+}));
+
+vi.mock("./infrastructures/i18n/routing", () => ({
+	routing: {
+		defaultLocale: "ja",
+		locales: ["en", "ja"],
+	},
+}));
+
+vi.mock("next-intl/middleware", async () => {
+	const { NextResponse: ActualNextResponse } =
+		await vi.importActual<typeof import("next/server")>("next/server");
+
+	return {
+		default: vi.fn(() => (request: NextRequest) => {
+			capturedRequests.push(request);
+			return ActualNextResponse.next({
+				request: { headers: request.headers },
+			});
+		}),
+	};
+});
+
+describe("proxy CSP", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedRequests.length = 0;
+		vi.mocked(getSessionCookie).mockReturnValue("session");
+	});
+
+	test("passes a unique nonce and enforced CSP upstream", () => {
+		const firstResponse = proxy(
+			new NextRequest("https://example.com/ja/articles"),
+		);
+		const secondResponse = proxy(
+			new NextRequest("https://example.com/ja/articles"),
+		);
+
+		const firstNonce = capturedRequests[0].headers.get("x-nonce");
+		const secondNonce = capturedRequests[1].headers.get("x-nonce");
+		const upstreamPolicy = capturedRequests[0].headers.get(
+			"content-security-policy",
+		);
+
+		expect(firstNonce).toBeTruthy();
+		expect(secondNonce).toBeTruthy();
+		expect(firstNonce).not.toBe(secondNonce);
+		expect(upstreamPolicy).toContain(`'nonce-${firstNonce}'`);
+		expect(firstResponse.headers.get("content-security-policy")).toBeNull();
+		expect(
+			firstResponse.headers.get("content-security-policy-report-only"),
+		).toBe(upstreamPolicy);
+		expect(
+			secondResponse.headers.get("content-security-policy-report-only"),
+		).toContain(`'nonce-${secondNonce}'`);
+	});
+
+	test("adds Report-Only CSP to unauthenticated redirects", () => {
+		vi.mocked(getSessionCookie).mockReturnValue(null);
+
+		const response = proxy(new NextRequest("https://example.com/ja/articles"));
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://example.com/api/sign-in",
+		);
+		expect(
+			response.headers.get("content-security-policy-report-only"),
+		).toContain("'nonce-");
+	});
+
+	test("excludes API and static asset routes from Proxy", () => {
+		expect(
+			unstable_doesMiddlewareMatch({
+				config,
+				nextConfig: {},
+				url: "/api/health",
+			}),
+		).toBe(false);
+		expect(
+			unstable_doesMiddlewareMatch({
+				config,
+				nextConfig: {},
+				url: "/_next/static/chunk.js",
+			}),
+		).toBe(false);
+		expect(
+			unstable_doesMiddlewareMatch({
+				config,
+				nextConfig: {},
+				url: "/ja/articles",
+			}),
+		).toBe(true);
+	});
+});

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -1,21 +1,67 @@
 import { getSessionCookie } from "better-auth/cookies";
 import createMiddleware from "next-intl/middleware";
-import { type NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { routing } from "./infrastructures/i18n/routing";
+import { buildContentSecurityPolicy } from "./infrastructures/security/content-security-policy";
 
 const handleI18nRouting = createMiddleware(routing);
+const CSP_HEADER = "Content-Security-Policy";
+const CSP_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
+
+function addCspResponseHeader(
+	response: NextResponse,
+	contentSecurityPolicy: string,
+): NextResponse {
+	response.headers.set(CSP_REPORT_ONLY_HEADER, contentSecurityPolicy);
+	return response;
+}
 
 // Middleware gate: a lightweight session-cookie presence check (no DB hit, so it
 // stays edge-friendly and avoids importing the Better Auth server instance).
 // True session validation happens per-page via requireAuth()/getSelfId(), which
 // call auth.api.getSession() and redirect to the unauthorized page on failure.
 export default function proxy(request: NextRequest) {
-	const sessionCookie = getSessionCookie(request);
+	const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+	// Proxy needs deployment metadata before the application env module is loaded.
+	// oxlint-disable-next-line node/no-process-env
+	const isDevelopment = process.env.NODE_ENV === "development";
+	// oxlint-disable-next-line node/no-process-env
+	const isPreview = process.env.VERCEL_ENV === "preview";
+	// oxlint-disable-next-line node/no-process-env
+	const minioHost = process.env.MINIO_HOST;
+	// oxlint-disable-next-line node/no-process-env
+	const minioPort = process.env.MINIO_PORT;
+	// oxlint-disable-next-line node/no-process-env
+	const reportUrl = process.env.SENTRY_REPORT_URL;
+	const contentSecurityPolicy = buildContentSecurityPolicy({
+		nonce,
+		isDevelopment,
+		isPreview,
+		minioHost,
+		minioPort,
+		reportUrl,
+	});
+	const requestHeaders = new Headers(request.headers);
+	requestHeaders.set("x-nonce", nonce);
+	// Next.js reads the enforced request header to apply the nonce during SSR.
+	// Only the Report-Only variant is exposed to the browser during rollout.
+	requestHeaders.set(CSP_HEADER, contentSecurityPolicy);
+	const requestWithCsp = new NextRequest(request, {
+		headers: requestHeaders,
+	});
+
+	const sessionCookie = getSessionCookie(requestWithCsp);
 	if (!sessionCookie) {
-		return NextResponse.redirect(new URL("/api/sign-in", request.url));
+		return addCspResponseHeader(
+			NextResponse.redirect(new URL("/api/sign-in", request.url)),
+			contentSecurityPolicy,
+		);
 	}
 
-	return handleI18nRouting(request);
+	return addCspResponseHeader(
+		handleI18nRouting(requestWithCsp),
+		contentSecurityPolicy,
+	);
 }
 
 export const config = {

--- a/app/vitest-setup.tsx
+++ b/app/vitest-setup.tsx
@@ -54,6 +54,9 @@ vi.mock("server-only", () => {
 
 vi.mock("next/cache", () => ({
 	cacheTag: vi.fn(),
+	unstable_cache: vi.fn(
+		(callback: (...args: unknown[]) => unknown) => callback,
+	),
 	updateTag: vi.fn(),
 }));
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 | `unauthorized()` | Next.js 15.1 | 未認証エラー用（401） |
 | `cacheTag()` | Next.js 15.1 | キャッシュタグによる無効化制御 |
 | `cacheLife()` | Next.js 15.1 | 15.0では`unstable_cacheLife`として提供 |
-| `"use cache"` | Next.js 15.0 | v16では`cacheComponents: true`で有効化 |
+| `unstable_cache` | Next.js 14.0 | nonce CSPと両立するデータキャッシュに使用 |
 | `connection()` | Next.js 15.0 | 動的レンダリングのオプトイン |
 
 ## 目次
@@ -21,7 +21,7 @@
 - [i18n Pattern](#i18n-pattern)
 - [Loader Pattern](#loader-pattern)
 - [Error Boundary Pattern](#error-boundary-pattern)
-- [Partial Prerendering (PPR)](#partial-prerendering-ppr)
+- [Nonce CSP とレンダリング](#nonce-csp-とレンダリング)
 - [Dynamic Rendering](#dynamic-rendering)
 - [Server Actions Architecture Pattern](#server-actions-architecture-pattern)
 - [Value Object Pattern with Zod Branding](#value-object-pattern-with-zod-branding)
@@ -480,62 +480,31 @@ export default function Error({ error, reset }: ErrorPageProps) {
 - `errorCaller`は問題追跡に使用されるため、コンポーネントを特定できる名前を付ける
 - Sentry連携によりプロダクションエラーを自動監視
 
-## Partial Prerendering (PPR)
+## Nonce CSP とレンダリング
 
-Next.js 15で導入されたPartial Prerenderingは、静的シェルと動的コンテンツを組み合わせるレンダリング戦略。
+本コードベースはスクリプトのインライン実行をnonceで制限する。Proxyがリクエストごとにnonceを生成し、Next.jsはリクエストの`Content-Security-Policy`からnonceを取得してframework scriptへ付与する。
 
-### 概要
+nonceはリクエストごとに異なるため、静的HTMLシェルを再利用するCache Components / PPRとは両立しない。そのため`cacheComponents`は有効化せず、ページはリクエスト時に動的レンダリングする。
 
-PPRは以下の特性を持つ:
-- **静的シェル**: ページの静的部分をビルド時にプリレンダリング
-- **動的ホール**: Suspense境界内の動的コンテンツを遅延読み込み
-- **ストリーミング**: 静的部分を即座に配信し、動的部分をストリーミング
+### データキャッシュ
 
-### 有効化
+動的レンダリングとデータキャッシュは分離する。Prismaを使うquery serviceは`unstable_cache`でキャッシュし、次の値をcache keyへ必ず含める:
 
-```typescript
-// app/next.config.mjs
-const nextConfig = {
-  cacheComponents: true, // v16: 静的シェル + 動的ストリーミング
-  reactCompiler: true,
-};
-```
+- ドメイン名
+- query種別
+- `userId`
+- status
+- pagination offset / page
 
-### Loader Pattern との組み合わせ
+既存のtenant別cache tagは維持し、Server Action内の`updateTag`でread-your-own-writesを保証する。公開query serviceはReactの`cache`も併用し、同一レンダリング内の重複呼び出しを抑止する。
 
-本コードベースのLoader Patternは、PPRと自然に統合できる:
+### Loader Pattern
 
-```typescript
-// 静的シェル（即座に配信）
-export default function ArticlesPage() {
-  return (
-    <div>
-      <Header /> {/* 静的 */}
-      <Sidebar /> {/* 静的 */}
-
-      {/* 動的ホール（Suspense境界内でストリーミング） */}
-      <Suspense fallback={<ArticlesSkeleton />}>
-        <ArticlesStackLoader variant="exported" />
-      </Suspense>
-    </div>
-  );
-}
-```
-
-**ポイント:**
-- 認証情報を必要としないUIコンポーネントは静的シェルとして即座に配信
-- データフェッチを伴うLoaderはSuspense境界内に配置し、動的ホールとして扱う
-- Skeleton/Loading UIを適切に設計し、ユーザー体験を最適化
-
-### 注意事項
-
-- PPRは現在experimental機能
-- `cookies()`, `headers()`, `searchParams`を使用するコンポーネントは自動的に動的になる
-- 静的/動的の境界を意識した設計が重要
+LoaderとSuspense境界は、PPRではなくリクエスト時ストリーミングとloading UIのために維持する。認証確認とnonce適用は静的シェルへ逃がさず、常に同じリクエストコンテキストで処理する。
 
 ## Dynamic Rendering
 
-Next.js 15での動的レンダリングの制御方法。
+Next.js 16での動的レンダリングの制御方法。
 
 ### 動的レンダリングのトリガー
 
@@ -547,22 +516,6 @@ Next.js 15での動的レンダリングの制御方法。
 | `headers()` | リクエストヘッダー読み取り |
 | `searchParams` | クエリパラメータ |
 | `connection()` | 明示的な動的オプトイン |
-
-### `cacheComponents` フラグ
-
-Next.js 16では`cacheComponents`フラグにより、IO操作の動的/静的な振る舞いを制御:
-
-```typescript
-// app/next.config.mjs
-const nextConfig = {
-  cacheComponents: true,
-};
-```
-
-`cacheComponents`有効時:
-- `fetch`、データベースクエリ等のIO操作はデフォルトで動的
-- `"use cache"`ディレクティブでキャッシュを明示的にオプトイン
-- 動的IOを行わないルートは自動的に静的プリレンダリング
 
 ### `connection()` API
 
@@ -586,9 +539,10 @@ async function DynamicComponent() {
 
 ### 本コードベースでの方針
 
-1. **デフォルト**: `"use cache"`でキャッシュし、`updateTag`で無効化（Server Action内）
-2. **認証が必要なページ**: 認証チェックにより自動的に動的
-3. **リアルタイム要件**: `connection()` APIで明示的にオプトイン
+1. **ページ**: nonce CSPのためリクエストごとに動的レンダリング
+2. **データ**: `unstable_cache`でtenant別にキャッシュし、`updateTag`で無効化
+3. **認証**: `headers()`を使ったsession検証をページ・Server Actionごとに実施
+4. **リアルタイム要件**: `connection()` APIで明示的にオプトイン
 
 ## Server Actions Architecture Pattern
 


### PR DESCRIPTION
## Summary

- generate a request-scoped nonce in Proxy and propagate it through `x-nonce`
- return the CSP as `Content-Security-Policy-Report-Only` during rollout
- apply environment-specific policies for React Scan and Vercel Toolbar
- disable Cache Components/PPR and migrate domain query caching to `unstable_cache`
- document the CSP enforcement criteria and rendering/cache architecture

## Verification

- `pnpm test` (129 files, 903 tests)
- targeted CSP, Proxy, and cache tests (8 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm deps:check`
- `pnpm format:check`
- production build with representative environment values
- confirmed unique nonces across requests and CSP headers on authentication redirects

## Follow-up

Keep the policy in Report-Only mode until authenticated Preview flows and production telemetry have no unexplained violations. Enforcement should be a separate change that only switches the response header name.