### PR TITLE
Disable Renovate `lockFileMaintenance` and update docs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
 	//     npm ジョブが "does not support your pnpm version" で失敗するため Renovate に戻した
 	//     (dependabot/dependabot-core#14794)。
 	//   - mise / nvm: ツールバージョン管理
-	//   - lockFileMaintenance: 四半期に pnpm-lock 全リフレッシュ
 	// github-actions / docker-compose は pnpm 非依存のため .github/dependabot.yml が担当。
 	enabledManagers: ["npm", "mise", "nvm"],
 	// self-host runner での pnpm install の lifecycle scripts (sharp /
@@ -38,11 +37,10 @@
 	rangeStrategy: "bump",
 	platformAutomerge: true,
 	automergeStrategy: "squash",
-	lockFileMaintenance: {
-		enabled: true,
-		automerge: false,
-		schedule: ["before 5am on the first day of january,april,july,october"],
-	},
+	// package.json の依存は完全固定され、通常の更新 PR でも pnpm-lock.yaml が更新される。
+	// 全推移依存だけを一括再解決する maintenance PR は、更新元が不明瞭な巨大差分や
+	// 推移依存の意図しないメジャー更新を生むため無効化する。
+	lockFileMaintenance: { enabled: false },
 	vulnerabilityAlerts: {
 		labels: ["security"],
 	},

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ This project uses [Renovate](https://docs.renovatebot.com/) for automated depend
 - **Grouped Updates**:
   - 非メジャー更新（patch + minor）を依存種別ごとに集約: `non-major`（dependencies / peerDependencies）と `non-major (devDependencies)`
   - `mise` ツール群、および Node.js + pnpm はそれぞれ専用グループ（`mise` / `node and pnpm`）
-- **Lock File Maintenance**: Automatic lock file updates to keep dependencies fresh
+- **Lock File Maintenance**: Disabled. Dependencies are version-pinned, and regular Renovate PRs update the lockfile together with their manifests; standalone full lockfile refreshes obscure which direct update caused transitive changes.
 
 **Renovate Settings**:
 ```json5
@@ -60,7 +60,8 @@ This project uses [Renovate](https://docs.renovatebot.com/) for automated depend
   vulnerabilityAlerts: {
     labels: ['security'],
   },
-  lockFileMaintenance: { enabled: true },
+  // Avoid standalone full re-resolution of transitive dependencies.
+  lockFileMaintenance: { enabled: false },
   packageRules: [
     // Four rules (npm deps, npm devDeps, mise, node/pnpm) all use:
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,7 @@ import { ArticlesStackLoader } from "@/loaders/articles";
 
 ### 自動依存関係管理（Renovate + Dependabot）
 - **役割分担**:
-  - **Renovate**: npm（pnpm）/ mise / nvm / 四半期の lockFileMaintenance。npm を Renovate が担当するのは、Dependabot のサポート上限が pnpm v10 で、本リポジトリの `packageManager`（pnpm@11）では npm ジョブが `does not support your pnpm version` で失敗するため（pnpm v11 サポートは未対応: dependabot/dependabot-core#14794）。
+  - **Renovate**: npm（pnpm）/ mise / nvm。npm を Renovate が担当するのは、Dependabot のサポート上限が pnpm v10 で、本リポジトリの `packageManager`（pnpm@11）では npm ジョブが `does not support your pnpm version` で失敗するため（pnpm v11 サポートは未対応: dependabot/dependabot-core#14794）。依存バージョンは完全固定され、通常の更新PRでlockfileも更新されるため、推移依存だけを一括再解決する `lockFileMaintenance` は無効。
   - **Dependabot**: pnpm 非依存の github-actions / docker-compose。低リスク更新は `dependabot-auto-merge.yaml` で auto-merge。
 - **スケジュール**: Renovate は週次（月曜日11時（JST）前）、Dependabot は日次（09:00 JST）。
 - **脆弱性アラート**: セキュリティ問題の自動PR（`security`ラベル付き、Renovate）


### PR DESCRIPTION
### Motivation
- Avoid standalone full re-resolution of transitive dependencies because package dependencies are fully pinned and standalone lockfile refreshes produce large, unclear diffs and unintended transitive major bumps.
- Keep Renovate behavior aligned with repository policy that regular dependency update PRs update the lockfile together with manifests.

### Description
- Update `.github/renovate.json5` to set `lockFileMaintenance: { enabled: false }` and add comments explaining the rationale and behavior change.
- Update `SECURITY.md` to reflect that lock file maintenance is disabled and explain why standalone lockfile refreshes are avoided.
- Update `docs/architecture.md` to remove the reference to quarterly `lockFileMaintenance` and clarify the Renovate role and lockfile policy.

### Testing
- No automated tests were run as this change is configuration and documentation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d2acb1f648329bb11acb1cecdfa52)