### PR TITLE
fix: allow Radix dialog scroll lock style in CSP

### DIFF
--- a/app/src/infrastructures/security/content-security-policy.test.ts
+++ b/app/src/infrastructures/security/content-security-policy.test.ts
@@ -19,7 +19,9 @@ describe("buildContentSecurityPolicy", () => {
 		expect(policy).toContain("script-src 'self' 'nonce-test-nonce'");
 		expect(policy).not.toMatch(/script-src[^;]*'unsafe-inline'/u);
 		expect(policy).not.toMatch(/script-src[^;]*'unsafe-eval'/u);
-		expect(policy).toContain("style-src-elem 'self' 'nonce-test-nonce'");
+		expect(policy).toContain(
+			"style-src-elem 'self' 'nonce-test-nonce' 'sha256-nzTgYzXYDNe6BAHiiI7NNlfK8n/auuOAhh2t92YvuXo='",
+		);
 		expect(policy).not.toMatch(/style-src-elem[^;]*'unsafe-inline'/u);
 		expect(policy).toContain("style-src-attr 'unsafe-inline'");
 		expect(policy).toContain(

--- a/app/src/infrastructures/security/content-security-policy.ts
+++ b/app/src/infrastructures/security/content-security-policy.ts
@@ -1,4 +1,8 @@
 const CSP_REPORTING_GROUP = "csp-endpoint";
+// react-remove-scroll injects this deterministic zero-width scrollbar rule when
+// Radix dialogs open on platforms with overlay scrollbars.
+const RADIX_DIALOG_SCROLL_LOCK_STYLE_HASH =
+	"'sha256-nzTgYzXYDNe6BAHiiI7NNlfK8n/auuOAhh2t92YvuXo='";
 
 type ContentSecurityPolicyOptions = {
 	isDevelopment: boolean;
@@ -45,7 +49,7 @@ export function buildContentSecurityPolicy({
 				"'unsafe-inline'",
 				...(allowsVercelToolbar ? ["https://vercel.live"] : []),
 			]
-		: ["'self'", `'nonce-${nonce}'`];
+		: ["'self'", `'nonce-${nonce}'`, RADIX_DIALOG_SCROLL_LOCK_STYLE_HASH];
 	const imageSources = [
 		"'self'",
 		"blob:",


### PR DESCRIPTION
### Motivation

- Radix dialogs (via `react-remove-scroll`) inject a deterministic inline `<style>` for scroll-lock on some platforms which triggered a CSP `style-src-elem` violation when opening the dumper delete dialog. This change aims to avoid loosening the CSP (no `unsafe-inline`) while allowing that specific known style.

### Description

- Add `RADIX_DIALOG_SCROLL_LOCK_STYLE_HASH` and include it in the production `style-src` / `style-src-elem` sources so the deterministic scroll-lock style is permitted alongside the existing nonce-based policy in `app/src/infrastructures/security/content-security-policy.ts`.
- Update the regression test in `app/src/infrastructures/security/content-security-policy.test.ts` to assert the hash is present in the built policy.

### Testing

- Ran unit tests: `vitest` for `app/src/infrastructures/security/content-security-policy.test.ts`, all tests passed (3 tests).
- Ran formatting and lint checks: `oxfmt --check` and `oxlint --type-aware` against the modified files, both succeeded after formatting.
- Verified there are no `git diff --check` style errors after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb1879ba4832981f7eb5a4f63e954)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修正

* **Bug Fixes**
  * ダイアログのスクロールロック機能が正常に動作するよう、セキュリティポリシーを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->