### PR TITLE
feat: invalidate content caches after batch status updates

### DIFF
--- a/app/src/app/api/internal/cache/invalidate/route.test.ts
+++ b/app/src/app/api/internal/cache/invalidate/route.test.ts
@@ -1,0 +1,60 @@
+import { updateTag } from "next/cache";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/env", () => ({
+	env: { CACHE_INVALIDATION_SECRET: "test-secret" },
+}));
+
+const { POST } = await import("./route");
+
+function createRequest(body: unknown, token = "test-secret"): Request {
+	return new Request("http://localhost/api/internal/cache/invalidate", {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${token}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+describe("POST /api/internal/cache/invalidate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("rejects an invalid bearer token", async () => {
+		const response = await POST(
+			createRequest({ domain: "books", userId: "user" }, "wrong-secret"),
+		);
+
+		expect(response.status).toBe(401);
+		expect(updateTag).not.toHaveBeenCalled();
+	});
+
+	test("rejects unsupported domains", async () => {
+		const response = await POST(
+			createRequest({ domain: "unsupported", userId: "user" }),
+		);
+
+		expect(response.status).toBe(400);
+		expect(updateTag).not.toHaveBeenCalled();
+	});
+
+	test("invalidates all before and after status caches", async () => {
+		const response = await POST(
+			createRequest({ domain: "books", userId: "user" }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({ invalidated: 6 });
+		expect(vi.mocked(updateTag).mock.calls.flat()).toEqual([
+			"books_UNEXPORTED_user",
+			"books_count_UNEXPORTED_user",
+			"books_LAST_UPDATED_user",
+			"books_count_LAST_UPDATED_user",
+			"books_EXPORTED_user",
+			"books_count_EXPORTED_user",
+		]);
+	});
+});

--- a/app/src/app/api/internal/cache/invalidate/route.ts
+++ b/app/src/app/api/internal/cache/invalidate/route.ts
@@ -1,0 +1,54 @@
+import { env } from "@/env";
+import {
+	CACHE_INVALIDATION_DOMAINS,
+	invalidateContentStatusCache,
+} from "@/infrastructures/shared/cache/invalidate-content-status-cache";
+import { timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+
+const requestSchema = z.object({
+	domain: z.enum(CACHE_INVALIDATION_DOMAINS),
+	userId: z.string().min(1),
+});
+
+function hasValidBearerToken(request: Request): boolean {
+	const secret = env.CACHE_INVALIDATION_SECRET;
+	const authorization = request.headers.get("authorization");
+	if (!secret || !authorization?.startsWith("Bearer ")) return false;
+
+	const supplied = authorization.slice("Bearer ".length);
+	const suppliedBuffer = Buffer.from(supplied);
+	const secretBuffer = Buffer.from(secret);
+
+	return (
+		suppliedBuffer.length === secretBuffer.length &&
+		timingSafeEqual(suppliedBuffer, secretBuffer)
+	);
+}
+
+export async function POST(request: Request): Promise<Response> {
+	if (!env.CACHE_INVALIDATION_SECRET) {
+		return Response.json(
+			{ error: "Cache invalidation is not configured" },
+			{ status: 503 },
+		);
+	}
+
+	if (!hasValidBearerToken(request)) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const parsed = requestSchema.safeParse(
+		await request.json().catch(() => null),
+	);
+	if (!parsed.success) {
+		return Response.json({ error: "Invalid request" }, { status: 400 });
+	}
+
+	const tags = invalidateContentStatusCache(
+		parsed.data.domain,
+		parsed.data.userId,
+	);
+
+	return Response.json({ invalidated: tags.length });
+}

--- a/app/src/env.ts
+++ b/app/src/env.ts
@@ -42,6 +42,8 @@ export const env = createEnv({
 			.default("https://api.pushover.net/1/messages.json"),
 		PUSHOVER_USER_KEY: z.string(),
 		PUSHOVER_APP_TOKEN: z.string(),
+		/** Shared bearer token used only by trusted batch scripts to invalidate Next.js caches. */
+		CACHE_INVALIDATION_SECRET: z.string().optional(),
 		/** Generate by `openssl rand -base64 32`. Required in production. Shared secret for Better Auth. */
 		AUTH_SECRET:
 			process.env.NODE_ENV === "production"
@@ -88,6 +90,7 @@ export const env = createEnv({
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
 		PUSHOVER_APP_TOKEN: process.env.PUSHOVER_APP_TOKEN,
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
 		AUTH_SECRET: process.env.AUTH_SECRET,
 		BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
 		VERCEL: process.env.VERCEL,

--- a/app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts
+++ b/app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts
@@ -1,0 +1,52 @@
+import { updateTag } from "next/cache";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { invalidateContentStatusCache } from "./invalidate-content-status-cache";
+
+describe("invalidateContentStatusCache", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test.each(["articles", "books", "images", "notes"] as const)(
+		"invalidates list and count tags for every %s status",
+		(domain) => {
+			const tags = invalidateContentStatusCache(domain, "user-123");
+
+			expect(tags).toEqual([
+				`${domain}_UNEXPORTED_user`,
+				`${domain}_count_UNEXPORTED_user`,
+				`${domain}_LAST_UPDATED_user`,
+				`${domain}_count_LAST_UPDATED_user`,
+				`${domain}_EXPORTED_user`,
+				`${domain}_count_EXPORTED_user`,
+			]);
+			expect(updateTag).toHaveBeenCalledTimes(6);
+			expect(vi.mocked(updateTag).mock.calls.flat()).toEqual(tags);
+		},
+	);
+
+	test("invalidates both sides of UNEXPORTED → LAST_UPDATED so the item disappears from Dumper", () => {
+		invalidateContentStatusCache("books", "user");
+
+		expect(updateTag).toHaveBeenCalledWith("books_UNEXPORTED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_count_LAST_UPDATED_user");
+	});
+
+	test("invalidates both sides of LAST_UPDATED → UNEXPORTED so the item reappears in Dumper", () => {
+		invalidateContentStatusCache("books", "user");
+
+		expect(updateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_count_LAST_UPDATED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_UNEXPORTED_user");
+		expect(updateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user");
+	});
+
+	test("uses shared list tags instead of enumerating paginated tags", () => {
+		const tags = invalidateContentStatusCache("books", "user");
+
+		expect(tags).not.toContain("books_UNEXPORTED_user_0");
+		expect(tags).not.toContain("books_LAST_UPDATED_user_0");
+	});
+});

--- a/app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts
+++ b/app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts
@@ -1,0 +1,44 @@
+import type { Status } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
+import {
+	buildContentCacheTag,
+	buildCountCacheTag,
+} from "@/infrastructures/shared/cache/cache-tag-builder";
+import { updateTag } from "next/cache";
+
+export const CACHE_INVALIDATION_DOMAINS = [
+	"articles",
+	"books",
+	"images",
+	"notes",
+] as const;
+
+export type CacheInvalidationDomain =
+	(typeof CACHE_INVALIDATION_DOMAINS)[number];
+
+const CONTENT_STATUSES = [
+	"UNEXPORTED",
+	"LAST_UPDATED",
+	"EXPORTED",
+] as const satisfies readonly Status[];
+
+/**
+ * Invalidates every status bucket affected by a batch status transition.
+ *
+ * Paginated queries also carry the non-paginated content tag, so invalidating
+ * that shared tag covers every page without enumerating pagination offsets.
+ */
+export function invalidateContentStatusCache(
+	domain: CacheInvalidationDomain,
+	userId: string,
+): string[] {
+	const tags = CONTENT_STATUSES.flatMap((status) => [
+		buildContentCacheTag(domain, status, userId),
+		buildCountCacheTag(domain, status, userId),
+	]);
+
+	for (const tag of tags) {
+		updateTag(tag);
+	}
+
+	return tags;
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,6 +56,15 @@ vercel env run -e development -- <command>   # Vercel dev 環境変数（prisma 
 環境変数のスキーマと型定義は `app/src/env.ts`（`@t3-oss/env-nextjs` + Zod）を参照してください。
 Docker Compose 用の変数（VPS デプロイ時）は [docs/vps-deployment.md Step 7](vps-deployment.md) を参照してください。
 
+外部の `reset-*` / `revert-*` バッチから Next.js のキャッシュを無効化する場合は、次の変数も設定します。
+
+| 変数 | 用途 |
+|---|---|
+| `CACHE_INVALIDATION_SECRET` | アプリとバッチで共有する内部 API の Bearer token（`openssl rand -base64 32` などで生成） |
+| `CACHE_INVALIDATION_URL` | バッチ側のみ。デプロイ済みアプリの `/api/internal/cache/invalidate` の絶対 URL |
+
+バッチの DB トランザクション成功後に内部 API を呼び出します。呼び出しに失敗した場合、DB 更新はロールバックされませんが、バッチ自体は失敗終了し、標準エラーと Pushover 通知に失敗を残します。
+
 ## Database (CockroachDB)
 
 DB ホスティングは **CockroachDB Cloud Basic**（region `gcp-asia-southeast1`）を使用します。Prisma ORM (`provider = "cockroachdb"`) 経由で接続し、`@prisma/adapter-pg` (node-postgres) で pgwire プロトコルで話します（CockroachDB は PostgreSQL ワイヤ互換）。

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"bench": "vitest bench --project bench",
 		"bench:components": "vitest bench --project app-bench",
 		"bench:all": "vitest bench --project bench --project app-bench",
-		"test": "vitest run --project app --project components --project core --project notification --project search --project storybook",
+		"test": "vitest run --project app --project components --project core --project notification --project scripts --project search --project storybook",
 		"test:watch": "vitest",
 		"typecheck": "pnpm --recursive typecheck",
 		"license:summary": "pnpm licenses list > library-license.txt",

--- a/packages/scripts/src/infrastructures/cache-invalidation-client.test.ts
+++ b/packages/scripts/src/infrastructures/cache-invalidation-client.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from "vitest";
+import { invalidateContentCache } from "./cache-invalidation-client.ts";
+
+describe("invalidateContentCache", () => {
+	test("calls the authenticated internal endpoint for the user and domain", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ invalidated: 6 }), { status: 200 }),
+			);
+
+		await invalidateContentCache(
+			{ url: "https://example.com/api/internal/cache/invalidate", secret: "s" },
+			"books",
+			"user",
+			fetchMock,
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://example.com/api/internal/cache/invalidate",
+			{
+				method: "POST",
+				headers: {
+					authorization: "Bearer s",
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ domain: "books", userId: "user" }),
+			},
+		);
+	});
+
+	test("throws with the response details so the caller logs and notifies failure", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+		await expect(
+			invalidateContentCache(
+				{ url: "https://example.com", secret: "wrong" },
+				"notes",
+				"user",
+				fetchMock,
+			),
+		).rejects.toThrow("Cache invalidation failed (401): unauthorized");
+	});
+});

--- a/packages/scripts/src/infrastructures/cache-invalidation-client.ts
+++ b/packages/scripts/src/infrastructures/cache-invalidation-client.ts
@@ -1,0 +1,37 @@
+export const CACHE_INVALIDATION_DOMAINS = [
+	"articles",
+	"books",
+	"images",
+	"notes",
+] as const;
+
+export type CacheInvalidationDomain =
+	(typeof CACHE_INVALIDATION_DOMAINS)[number];
+
+type CacheInvalidationConfig = Readonly<{
+	url: string;
+	secret: string;
+}>;
+
+export async function invalidateContentCache(
+	config: CacheInvalidationConfig,
+	domain: CacheInvalidationDomain,
+	userId: string,
+	fetchImplementation: typeof fetch = fetch,
+): Promise<void> {
+	const response = await fetchImplementation(config.url, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${config.secret}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({ domain, userId }),
+	});
+
+	if (!response.ok) {
+		const responseBody = await response.text();
+		throw new Error(
+			`Cache invalidation failed (${response.status}): ${responseBody}`,
+		);
+	}
+}

--- a/packages/scripts/src/reset-articles.ts
+++ b/packages/scripts/src/reset-articles.ts
@@ -6,9 +6,12 @@ import {
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
 import { createArticlesCommandRepository } from "./infrastructures/articles-command-repository.ts";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -40,6 +43,17 @@ async function main() {
 
 		// Execute batch reset through domain service
 		const result = await batchService.resetArticles(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"articles",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの記事をEXPORTEDに変更しました（${result.finalized.count}件）`,

--- a/packages/scripts/src/reset-books.ts
+++ b/packages/scripts/src/reset-books.ts
@@ -6,9 +6,12 @@ import {
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
 import { createBooksCommandRepository } from "./infrastructures/books-command-repository.ts";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -38,6 +41,17 @@ async function main() {
 		const batchService = new BooksBatchDomainService(commandRepository);
 
 		const result = await batchService.resetBooks(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"books",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの本をEXPORTEDに変更しました（${result.finalized.count}件）`,

--- a/packages/scripts/src/reset-images.ts
+++ b/packages/scripts/src/reset-images.ts
@@ -5,10 +5,13 @@ import {
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 import { createImagesCommandRepository } from "./infrastructures/images-command-repository.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -38,6 +41,17 @@ async function main() {
 		const batchService = new ImagesBatchDomainService(commandRepository);
 
 		const result = await batchService.resetImages(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"images",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの画像をEXPORTEDに変更しました（${result.finalized.count}件）`,

--- a/packages/scripts/src/reset-notes.ts
+++ b/packages/scripts/src/reset-notes.ts
@@ -5,10 +5,13 @@ import {
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 import { createNotesCommandRepository } from "./infrastructures/notes-command-repository.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -38,6 +41,17 @@ async function main() {
 		const batchService = new NotesBatchDomainService(commandRepository);
 
 		const result = await batchService.resetNotes(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"notes",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDのノートをEXPORTEDに変更しました（${result.finalized.count}件）`,

--- a/packages/scripts/src/revert-articles.ts
+++ b/packages/scripts/src/revert-articles.ts
@@ -6,9 +6,12 @@ import {
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
 import { createArticlesCommandRepository } from "./infrastructures/articles-command-repository.ts";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -39,6 +42,17 @@ async function main() {
 
 		// Execute batch revert through domain service
 		const result = await batchService.revertArticles(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"articles",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの記事をUNEXPORTEDに変更しました（${result.count}件）`,

--- a/packages/scripts/src/revert-books.ts
+++ b/packages/scripts/src/revert-books.ts
@@ -6,9 +6,12 @@ import {
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
 import { createBooksCommandRepository } from "./infrastructures/books-command-repository.ts";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -36,6 +39,17 @@ async function main() {
 		const batchService = new BooksBatchDomainService(commandRepository);
 
 		const result = await batchService.revertBooks(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"books",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの本をUNEXPORTEDに変更しました（${result.count}件）`,

--- a/packages/scripts/src/revert-images.ts
+++ b/packages/scripts/src/revert-images.ts
@@ -5,10 +5,13 @@ import {
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 import { createImagesCommandRepository } from "./infrastructures/images-command-repository.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -36,6 +39,17 @@ async function main() {
 		const batchService = new ImagesBatchDomainService(commandRepository);
 
 		const result = await batchService.revertImages(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"images",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDの画像をUNEXPORTEDに変更しました（${result.count}件）`,

--- a/packages/scripts/src/revert-notes.ts
+++ b/packages/scripts/src/revert-notes.ts
@@ -5,10 +5,13 @@ import {
 	type UserId,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { createPushoverService } from "@s-hirano-ist/s-notification";
+import { invalidateContentCache } from "./infrastructures/cache-invalidation-client.ts";
 import { createNotesCommandRepository } from "./infrastructures/notes-command-repository.ts";
 
 async function main() {
 	const env = {
+		CACHE_INVALIDATION_SECRET: process.env.CACHE_INVALIDATION_SECRET,
+		CACHE_INVALIDATION_URL: process.env.CACHE_INVALIDATION_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		PUSHOVER_URL: process.env.PUSHOVER_URL,
 		PUSHOVER_USER_KEY: process.env.PUSHOVER_USER_KEY,
@@ -36,6 +39,17 @@ async function main() {
 		const batchService = new NotesBatchDomainService(commandRepository);
 
 		const result = await batchService.revertNotes(userId);
+
+		// The database transaction has committed at this point. A cache failure is
+		// treated as a failed batch run so it is logged and sent to Pushover.
+		await invalidateContentCache(
+			{
+				url: env.CACHE_INVALIDATION_URL ?? "",
+				secret: env.CACHE_INVALIDATION_SECRET ?? "",
+			},
+			"notes",
+			userId,
+		);
 
 		console.log(
 			`💾 LAST_UPDATEDのノートをUNEXPORTEDに変更しました（${result.count}件）`,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,14 @@ export default defineConfig({
 					},
 				},
 			},
+			// External batch scripts and their infrastructure clients
+			{
+				test: {
+					name: "scripts",
+					root: "./packages/scripts",
+					include: ["./src/**/*.test.?(c|m)[jt]s?(x)"],
+				},
+			},
 			// Benchmarks (Node environment, used by `vitest bench --project bench`)
 			{
 				test: {


### PR DESCRIPTION
### Motivation

- External Node.js batch scripts cannot call `next/cache` (`updateTag`) directly, so the app needs an authenticated internal API to let scripts invalidate Next.js cache after status transitions. 
- When batches move items between `UNEXPORTED`, `LAST_UPDATED`, and `EXPORTED`, both sides of the transition must be invalidated so list and count views (including Dumper) update correctly. 

### Description

- Add an authenticated internal endpoint `POST /api/internal/cache/invalidate` implemented in `app/src/app/api/internal/cache/invalidate/route.ts` that accepts `domain` and `userId` and validates a bearer token from `env.CACHE_INVALIDATION_SECRET`. 
- Implement `invalidateContentStatusCache` in `app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts` which uses `buildContentCacheTag()` and `buildCountCacheTag()` to call `updateTag()` for `UNEXPORTED`, `LAST_UPDATED`, and `EXPORTED` for the given domain and user, avoiding enumeration of paginated tags. 
- Add a scripts-side client `packages/scripts/src/infrastructures/cache-invalidation-client.ts` used by `reset-*` and `revert-*` scripts to call the internal API; client surfaces non-2xx responses as errors so callers can log/notify. 
- Wire cache invalidation calls into all batch scripts (`packages/scripts/src/reset-*.ts` and `revert-*.ts`) to run after the DB transaction completes, and keep existing error handling so cache failures are logged and reported (Pushover) and cause the batch to fail. 
- Expose `CACHE_INVALIDATION_SECRET` in `app/src/env.ts` and document `CACHE_INVALIDATION_URL`/`CACHE_INVALIDATION_SECRET` usage and failure semantics in `docs/setup.md`. 
- Add unit tests for the invalidation utility and the internal route, and include the `packages/scripts` test project in `vitest.config.ts`.

### Testing

- Ran unit tests with `pnpm exec vitest run --project app --project scripts` and related focused runs; test suites passed (app + scripts tests executed successfully). 
- Ran type checks with `pnpm --filter @s-hirano-ist/s-scripts typecheck` and `pnpm --filter s-private-app typecheck`, both succeeded. 
- Ran lint and format checks with `pnpm lint` and `pnpm format:check`, both succeeded. 
- Ran dependency rules with `pnpm deps:check`, which completed with only two pre-existing orphan warnings (no new errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb48a8e20832988729b93668f06eb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * コンテンツキャッシュを無効化する内部APIシステムを実装しました。キャッシュ無効化クライアント、複数のバッチスクリプト統合、および関連テストを含みます。

* **Tests**
  * キャッシュシステムの動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->