### PR TITLE
fix: use revalidateTag in cache invalidation route

### DIFF
--- a/app/src/app/api/internal/cache/invalidate/route.test.ts
+++ b/app/src/app/api/internal/cache/invalidate/route.test.ts
@@ -1,8 +1,13 @@
-import { updateTag } from "next/cache";
+import { serverLogger } from "@/infrastructures/observability/server";
+import { revalidateTag } from "next/cache";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+const mockedEnv = {
+	CACHE_INVALIDATION_SECRET: "test-secret" as string | undefined,
+};
+
 vi.mock("@/env", () => ({
-	env: { CACHE_INVALIDATION_SECRET: "test-secret" },
+	env: mockedEnv,
 }));
 
 const { POST } = await import("./route");
@@ -18,9 +23,45 @@ function createRequest(body: unknown, token = "test-secret"): Request {
 	});
 }
 
+function createInvalidJsonRequest(token = "test-secret"): Request {
+	return new Request("http://localhost/api/internal/cache/invalidate", {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${token}`,
+			"content-type": "application/json",
+		},
+		body: "{",
+	});
+}
+
 describe("POST /api/internal/cache/invalidate", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockedEnv.CACHE_INVALIDATION_SECRET = "test-secret";
+	});
+
+	test("returns 503 when cache invalidation is not configured", async () => {
+		mockedEnv.CACHE_INVALIDATION_SECRET = undefined;
+
+		const response = await POST(
+			createRequest({ domain: "books", userId: "user" }),
+		);
+
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toEqual({
+			error: "Cache invalidation is not configured",
+		});
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test("rejects a missing bearer token", async () => {
+		const request = createRequest({ domain: "books", userId: "user" });
+		request.headers.delete("authorization");
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
 	});
 
 	test("rejects an invalid bearer token", async () => {
@@ -29,16 +70,30 @@ describe("POST /api/internal/cache/invalidate", () => {
 		);
 
 		expect(response.status).toBe(401);
-		expect(updateTag).not.toHaveBeenCalled();
+		expect(revalidateTag).not.toHaveBeenCalled();
 	});
 
-	test("rejects unsupported domains", async () => {
-		const response = await POST(
-			createRequest({ domain: "unsupported", userId: "user" }),
-		);
+	test.each([
+		["unsupported domain", { domain: "unsupported", userId: "user" }],
+		["missing domain", { userId: "user" }],
+		["empty domain", { domain: "", userId: "user" }],
+		["missing userId", { domain: "books" }],
+		["empty userId", { domain: "books", userId: "" }],
+	])("rejects %s", async (_caseName, body) => {
+		const response = await POST(createRequest(body));
 
 		expect(response.status).toBe(400);
-		expect(updateTag).not.toHaveBeenCalled();
+		await expect(response.json()).resolves.toEqual({
+			error: "Invalid request",
+		});
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test("rejects malformed JSON", async () => {
+		const response = await POST(createInvalidJsonRequest());
+
+		expect(response.status).toBe(400);
+		expect(revalidateTag).not.toHaveBeenCalled();
 	});
 
 	test("invalidates all before and after status caches", async () => {
@@ -48,13 +103,45 @@ describe("POST /api/internal/cache/invalidate", () => {
 
 		expect(response.status).toBe(200);
 		await expect(response.json()).resolves.toEqual({ invalidated: 6 });
-		expect(vi.mocked(updateTag).mock.calls.flat()).toEqual([
-			"books_UNEXPORTED_user",
-			"books_count_UNEXPORTED_user",
-			"books_LAST_UPDATED_user",
-			"books_count_LAST_UPDATED_user",
-			"books_EXPORTED_user",
-			"books_count_EXPORTED_user",
-		]);
+		expect(vi.mocked(revalidateTag).mock.calls).toEqual(
+			[
+				"books_UNEXPORTED_user",
+				"books_count_UNEXPORTED_user",
+				"books_LAST_UPDATED_user",
+				"books_count_LAST_UPDATED_user",
+				"books_EXPORTED_user",
+				"books_count_EXPORTED_user",
+			].map((tag) => [tag, { expire: 0 }]),
+		);
+	});
+
+	test("returns a controlled 500 response and logs unexpected errors", async () => {
+		const error = new Error("cache failure");
+		vi.mocked(revalidateTag).mockImplementationOnce(() => {
+			throw error;
+		});
+
+		const response = await POST(
+			createRequest({ domain: "books", userId: "user" }),
+		);
+
+		expect(response.status).toBe(500);
+		const responseBody = await response.json();
+		expect(responseBody).toEqual({
+			error: "Failed to invalidate content cache",
+		});
+		expect(serverLogger.error).toHaveBeenCalledWith(
+			"Failed to invalidate content cache",
+			{
+				caller: "POST /api/internal/cache/invalidate",
+				status: 500,
+				userId: "user",
+				additionalContext: {
+					domain: "books",
+				},
+			},
+			error,
+		);
+		expect(JSON.stringify(responseBody)).not.toContain("test-secret");
 	});
 });

--- a/app/src/app/api/internal/cache/invalidate/route.ts
+++ b/app/src/app/api/internal/cache/invalidate/route.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { serverLogger } from "@/infrastructures/observability/server";
 import {
 	CACHE_INVALIDATION_DOMAINS,
 	invalidateContentStatusCache,
@@ -45,10 +46,30 @@ export async function POST(request: Request): Promise<Response> {
 		return Response.json({ error: "Invalid request" }, { status: 400 });
 	}
 
-	const tags = invalidateContentStatusCache(
-		parsed.data.domain,
-		parsed.data.userId,
-	);
+	try {
+		const tags = invalidateContentStatusCache(
+			parsed.data.domain,
+			parsed.data.userId,
+		);
 
-	return Response.json({ invalidated: tags.length });
+		return Response.json({ invalidated: tags.length });
+	} catch (error) {
+		serverLogger.error(
+			"Failed to invalidate content cache",
+			{
+				caller: "POST /api/internal/cache/invalidate",
+				status: 500,
+				userId: parsed.data.userId,
+				additionalContext: {
+					domain: parsed.data.domain,
+				},
+			},
+			error,
+		);
+
+		return Response.json(
+			{ error: "Failed to invalidate content cache" },
+			{ status: 500 },
+		);
+	}
 }

--- a/app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts
+++ b/app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { invalidateContentStatusCache } from "./invalidate-content-status-cache";
 
@@ -20,27 +20,47 @@ describe("invalidateContentStatusCache", () => {
 				`${domain}_EXPORTED_user`,
 				`${domain}_count_EXPORTED_user`,
 			]);
-			expect(updateTag).toHaveBeenCalledTimes(6);
-			expect(vi.mocked(updateTag).mock.calls.flat()).toEqual(tags);
+			expect(revalidateTag).toHaveBeenCalledTimes(tags.length);
+			expect(vi.mocked(revalidateTag).mock.calls).toEqual(
+				tags.map((tag) => [tag, { expire: 0 }]),
+			);
 		},
 	);
 
 	test("invalidates both sides of UNEXPORTED → LAST_UPDATED so the item disappears from Dumper", () => {
 		invalidateContentStatusCache("books", "user");
 
-		expect(updateTag).toHaveBeenCalledWith("books_UNEXPORTED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_count_LAST_UPDATED_user");
+		expect(revalidateTag).toHaveBeenCalledWith("books_UNEXPORTED_user", {
+			expire: 0,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user", {
+			expire: 0,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user", {
+			expire: 0,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith(
+			"books_count_LAST_UPDATED_user",
+			{ expire: 0 },
+		);
 	});
 
 	test("invalidates both sides of LAST_UPDATED → UNEXPORTED so the item reappears in Dumper", () => {
 		invalidateContentStatusCache("books", "user");
 
-		expect(updateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_count_LAST_UPDATED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_UNEXPORTED_user");
-		expect(updateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user");
+		expect(revalidateTag).toHaveBeenCalledWith("books_LAST_UPDATED_user", {
+			expire: 0,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith(
+			"books_count_LAST_UPDATED_user",
+			{ expire: 0 },
+		);
+		expect(revalidateTag).toHaveBeenCalledWith("books_UNEXPORTED_user", {
+			expire: 0,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith("books_count_UNEXPORTED_user", {
+			expire: 0,
+		});
 	});
 
 	test("uses shared list tags instead of enumerating paginated tags", () => {

--- a/app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts
+++ b/app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts
@@ -3,7 +3,7 @@ import {
 	buildContentCacheTag,
 	buildCountCacheTag,
 } from "@/infrastructures/shared/cache/cache-tag-builder";
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 
 export const CACHE_INVALIDATION_DOMAINS = [
 	"articles",
@@ -37,7 +37,7 @@ export function invalidateContentStatusCache(
 	]);
 
 	for (const tag of tags) {
-		updateTag(tag);
+		revalidateTag(tag, { expire: 0 });
 	}
 
 	return tags;

--- a/app/vitest-setup.tsx
+++ b/app/vitest-setup.tsx
@@ -57,6 +57,7 @@ vi.mock("next/cache", () => ({
 	unstable_cache: vi.fn(
 		(callback: (...args: unknown[]) => unknown) => callback,
 	),
+	revalidateTag: vi.fn(),
 	updateTag: vi.fn(),
 }));
 


### PR DESCRIPTION
### Motivation

- The cache invalidation endpoint is invoked from a Next.js Route Handler and previously called `updateTag`, which is only allowed inside Server Actions and caused HTTP 500 errors when called from the Route Handler. 
- The goal is to make the endpoint usable from external batches by switching to a Route-Handler-safe API and improving error handling and tests.

### Description

- Replaced `updateTag(tag)` with `revalidateTag(tag, { expire: 0 })` in the cache invalidation implementation so Route Handlers immediately expire target tags. (`app/src/infrastructures/shared/cache/invalidate-content-status-cache.ts`).
- Added `revalidateTag` to the test mock setup and updated tests to assert calls include the second argument `{ expire: 0 }`. (`app/vitest-setup.tsx`, `app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts`).
- Wrapped the cache invalidation call in the Route Handler with a try/catch and logged errors via the server logger while returning a controlled HTTP 500 JSON response (without leaking secrets or Authorization headers). (`app/src/app/api/internal/cache/invalidate/route.ts`).
- Expanded Route Handler tests to cover: service not configured (503), missing/invalid bearer token (401), input validation and malformed JSON (400), success (200) verifying `revalidateTag(..., { expire: 0 })`, and controlled 500 behavior + server logging. (`app/src/app/api/internal/cache/invalidate/route.test.ts`).

### Testing

- Ran focused unit tests for the changed modules with `pnpm exec vitest run --project app app/src/infrastructures/shared/cache/invalidate-content-status-cache.test.ts app/src/app/api/internal/cache/invalidate/route.test.ts` and they passed. 
- Ran formatting, lint and type checks with `pnpm format:check`, `pnpm lint`, and `pnpm typecheck` and all passed for the codebase.
- Ran broader test and dependency checks with `pnpm exec vitest run --project app --project components --project core --project notification --project scripts --project search` and `pnpm deps:check`; non-browser tests passed (84 files / 690 tests) and dependency checks reported no blocking errors.
- Note: `pnpm test` for the full workspace initially failed to run the Storybook browser project because Playwright browsers are not installed in the environment (Playwright requested `pnpm exec playwright install`); all non-browser tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3000d30c6c8329a01403bf0e184b8b)