### PR TITLE
fix: allow same-origin Next.js scripts in CSP

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -222,7 +222,8 @@ responses receive the enforced `Content-Security-Policy` header.
 
 ### Policy
 
-- `script-src` permits self, the request nonce, Vercel Analytics, development-only React Scan, and Preview-only Vercel Toolbar.
+- `script-src` permits self, the request nonce, the deterministic Next.js client-only dynamic-component bootstrap hash, Vercel Analytics, development-only React Scan, and Preview-only Vercel Toolbar.
+- The policy intentionally omits `strict-dynamic`: same-origin Next.js framework and chunk scripts are authorized by `self`, while inline scripts still require the request nonce or the documented bootstrap hash.
 - Production does not allow `unsafe-inline` or `unsafe-eval` for scripts.
 - Production `style-src-elem` requires self or the request nonce.
 - `style-src-attr 'unsafe-inline'` remains enabled because UI positioning and syntax highlighting use dynamic style attributes.
@@ -232,10 +233,13 @@ responses receive the enforced `Content-Security-Policy` header.
 
 ### Enforcement verification
 
-Exercise authentication, locale navigation, theme switching, Toast, Dialog,
-Drawer, Lightbox, and Markdown code rendering in Preview after policy changes.
-Confirm that Sentry contains no unexplained violations from supported browsers.
-Preview intentionally has a broader Vercel Toolbar policy than Production.
+After a Production deployment, inspect `/ja/images` and confirm every
+`/_next/static/chunks/*.js` request succeeds. Exercise the image dumper and
+Lightbox, locale navigation, theme switching, and Vercel Analytics, and confirm
+that the browser console and Sentry contain no unexplained CSP violations.
+Also exercise authentication, Toast, Dialog, Drawer, and Markdown code
+rendering in Preview. Preview intentionally has a broader Vercel Toolbar policy
+than Production.
 
 Cache Components / PPR are intentionally disabled because their reusable static
 HTML shell cannot carry a fresh nonce for every request. Database query results

--- a/app/src/infrastructures/security/content-security-policy.test.ts
+++ b/app/src/infrastructures/security/content-security-policy.test.ts
@@ -16,10 +16,11 @@ describe("buildContentSecurityPolicy", () => {
 			isPreview: false,
 		});
 
+		expect(policy).toContain("script-src 'self' 'nonce-test-nonce'");
 		expect(policy).toContain(
-			"script-src 'self' 'nonce-test-nonce' 'strict-dynamic'",
+			"'sha256-yC26i5HOTs5Y8b0pJJYwrKSJdGVBgseV2IRWZZkuY0w='",
 		);
-		expect(policy).not.toMatch(/script-src[^;]*'sha256-/u);
+		expect(policy).not.toMatch(/script-src[^;]*'strict-dynamic'/u);
 		expect(policy).not.toMatch(/script-src[^;]*'unsafe-inline'/u);
 		expect(policy).not.toMatch(/script-src[^;]*'unsafe-eval'/u);
 		expect(policy).toContain(

--- a/app/src/infrastructures/security/content-security-policy.ts
+++ b/app/src/infrastructures/security/content-security-policy.ts
@@ -3,6 +3,10 @@ const CSP_REPORTING_GROUP = "csp-endpoint";
 // Radix dialogs open on platforms with overlay scrollbars.
 const RADIX_DIALOG_SCROLL_LOCK_STYLE_HASH =
 	"'sha256-nzTgYzXYDNe6BAHiiI7NNlfK8n/auuOAhh2t92YvuXo='";
+// Next.js emits this deterministic inline bootstrap when a client-only dynamic
+// component (the image lightbox) is rendered beneath a Suspense boundary.
+const NEXT_DYNAMIC_COMPONENT_BOOTSTRAP_SCRIPT_HASH =
+	"'sha256-yC26i5HOTs5Y8b0pJJYwrKSJdGVBgseV2IRWZZkuY0w='";
 
 type ContentSecurityPolicyOptions = {
 	isDevelopment: boolean;
@@ -39,7 +43,7 @@ export function buildContentSecurityPolicy({
 	const scriptSources = [
 		"'self'",
 		`'nonce-${nonce}'`,
-		"'strict-dynamic'",
+		NEXT_DYNAMIC_COMPONENT_BOOTSTRAP_SCRIPT_HASH,
 		...(isDevelopment ? ["'unsafe-eval'", "https://unpkg.com"] : []),
 		"https://va.vercel-scripts.com",
 		...(allowsVercelToolbar ? ["https://vercel.live"] : []),

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -58,6 +58,8 @@ describe("proxy CSP", () => {
 		expect(secondNonce).toBeTruthy();
 		expect(firstNonce).not.toBe(secondNonce);
 		expect(upstreamPolicy).toContain(`'nonce-${firstNonce}'`);
+		expect(upstreamPolicy).toMatch(/script-src[^;]*'self'/u);
+		expect(upstreamPolicy).not.toMatch(/script-src[^;]*'strict-dynamic'/u);
 		expect(firstResponse.headers.get("content-security-policy")).toBe(
 			upstreamPolicy,
 		);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,8 @@ export default function Error({ error, reset }: ErrorPageProps) {
 
 本コードベースはスクリプトのインライン実行をnonceで制限する。Proxyがリクエストごとにnonceを生成し、Next.jsはリクエストの`Content-Security-Policy`からnonceを取得してframework scriptへ付与する。
 
+`script-src`では`'strict-dynamic'`を使用しない。同一オリジンのNext.js framework/chunk scriptは`'self'`で許可し、インラインscriptはリクエストnonceで許可する。Image dumperのLightboxは`ssr: false`のdynamic componentであり、Suspense配下でNext.jsが生成するnonceなしの決定的なbootstrap scriptだけは、production HTMLで内容を確認した固定hashで明示的に許可する。Next.js更新時はproduction buildの`/ja/images` HTMLでscript内容とhashを再検証し、生成内容がビルドごとに変化する場合はhashを追加せず、該当componentをサーバー側でレンダリング可能な構造へ変更する。
+
 nonceはリクエストごとに異なるため、静的HTMLシェルを再利用するCache Components / PPRとは両立しない。そのため`cacheComponents`は有効化せず、ページはリクエスト時に動的レンダリングする。
 
 ### データキャッシュ


### PR DESCRIPTION
### Motivation

- Ensure Next.js same-origin framework and static chunk scripts are authorized by `'self'` instead of relying on `'strict-dynamic'`, while still protecting inline scripts with a request-scoped nonce.
- Allow the deterministic inline bootstrap emitted for the image lightbox dynamic component when rendered under a `Suspense` boundary if its content is stable across builds.
- Provide regression coverage and documentation so future Next.js changes are validated and the bootstrap-hash approach is re-evaluated after production builds.

### Description

- Removed `'strict-dynamic'` from `script-src` and restored an explicit `NEXT_DYNAMIC_COMPONENT_BOOTSTRAP_SCRIPT_HASH` constant which is included in the script sources when appropriate in `app/src/infrastructures/security/content-security-policy.ts`.
- Updated `app/src/infrastructures/security/content-security-policy.test.ts` to assert that the production policy contains `'self'`, the request nonce, and (if present) the documented bootstrap hash while rejecting `'strict-dynamic'`.
- Added a proxy-level regression assertion in `app/src/proxy.test.ts` to verify the upstream CSP contains `'self'` and does not rely on `'strict-dynamic'` for same-origin chunk loading.
- Updated `SECURITY.md` and `docs/architecture.md` to document the nonce model, the same-origin chunk policy, the bootstrap-hash exception, and the required post-deployment verification steps for `/ja/images` and the Lightbox flow.

### Testing

- Ran unit tests with `pnpm vitest run --project app app/src/infrastructures/security/content-security-policy.test.ts app/src/proxy.test.ts`, and all tests passed (2 test files, 6 tests total). 
- Ran formatting and lint checks with `pnpm format:check` and `pnpm lint`, both succeeded. 
- Performed a production build with `CI=1 pnpm --filter s-private-app build` using local placeholder environment configuration and `SKIP_ENV_VALIDATION` where needed, and the Next.js production compile completed; environment-dependent runtime verification of `/ja/images` (authenticated browser check) could not be performed locally and is documented as a required post-deployment verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3006b5c9b48329abf3f6a5de01dc62)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * セキュリティポリシーの詳細を更新し、本番環境でのコンテンツセキュリティポリシー実装と検証手順を明確化しました。
  * アーキテクチャドキュメントにスクリプト許可方針と運用ガイドラインを追加しました。

* **Tests**
  * セキュリティ関連テストを更新し、ポリシー実装の正確性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->