### PR TITLE
Avoid server dynamic Lightbox bootstrap

### DIFF
--- a/app/src/components/common/display/image/image-stack.tsx
+++ b/app/src/components/common/display/image/image-stack.tsx
@@ -1,17 +1,25 @@
 "use client";
 import type { DeleteAction } from "@/common/types";
+import type { LightboxExternalProps } from "yet-another-react-lightbox";
 import { DeleteButtonWithModal } from "@/components/common/forms/actions/delete-button-with-modal";
 import { StatusCodeView } from "@s-hirano-ist/s-ui/display/status/status-code-view";
 import { haptic } from "@s-hirano-ist/s-ui/utils/haptic";
 import { useTranslations } from "next-intl";
-import dynamic from "next/dynamic";
 import Image from "next/image";
 import "yet-another-react-lightbox/styles.css";
 import { useState } from "react";
 
-const Lightbox = dynamic(() => import("yet-another-react-lightbox"), {
-	ssr: false,
-});
+type LightboxComponent = React.ComponentType<LightboxExternalProps>;
+
+let lightboxPromise: Promise<LightboxComponent> | undefined;
+
+function loadLightbox(): Promise<LightboxComponent> {
+	lightboxPromise ??= import("yet-another-react-lightbox").then(
+		(module) => module.default,
+	);
+
+	return lightboxPromise;
+}
 
 export type ImageData = {
 	id?: string;
@@ -89,6 +97,8 @@ type ImageStackProps = {
 export function ImageStack({ data }: ImageStackProps) {
 	const [open, setOpen] = useState(false);
 	const [index, setIndex] = useState(0);
+	const [lightboxComponent, setLightboxComponent] =
+		useState<LightboxComponent>();
 	const t = useTranslations("statusCode");
 
 	if (data.length === 0)
@@ -101,23 +111,29 @@ export function ImageStack({ data }: ImageStackProps) {
 		alt: `Image ${image.originalPath}`,
 	}));
 
+	const Lightbox = lightboxComponent;
+
 	const handleImageClick = (imageIndex: number) => {
 		haptic();
 		setIndex(imageIndex);
-		setOpen(true);
+		void loadLightbox().then((component) => {
+			setLightboxComponent(() => component);
+			setOpen(true);
+			return null;
+		});
 	};
 
 	return (
 		<>
 			<ImageStackGrid data={data} onImageClick={handleImageClick} />
-			{open && (
+			{open && Lightbox ? (
 				<Lightbox
 					close={() => setOpen(false)}
 					index={index}
 					open={open}
 					slides={slides}
 				/>
-			)}
+			) : null}
 		</>
 	);
 }
@@ -133,6 +149,8 @@ export function EditableImageStack({
 }: EditableImageStackProps) {
 	const [open, setOpen] = useState(false);
 	const [index, setIndex] = useState(0);
+	const [lightboxComponent, setLightboxComponent] =
+		useState<LightboxComponent>();
 	const t = useTranslations("statusCode");
 
 	if (data.length === 0)
@@ -145,6 +163,8 @@ export function EditableImageStack({
 		alt: `Image ${image.originalPath}`,
 	}));
 
+	const Lightbox = lightboxComponent;
+
 	return (
 		<>
 			<ImageStackGrid
@@ -152,7 +172,11 @@ export function EditableImageStack({
 				onImageClick={(i) => {
 					setIndex(i);
 					haptic();
-					setOpen(true);
+					void loadLightbox().then((component) => {
+						setLightboxComponent(() => component);
+						setOpen(true);
+						return null;
+					});
 				}}
 				renderOverlay={(image) =>
 					image.id ? (
@@ -164,14 +188,14 @@ export function EditableImageStack({
 					) : null
 				}
 			/>
-			{open && (
+			{open && Lightbox ? (
 				<Lightbox
 					close={() => setOpen(false)}
 					index={index}
 					open={open}
 					slides={slides}
 				/>
-			)}
+			) : null}
 		</>
 	);
 }


### PR DESCRIPTION
### Motivation
- Prevent Next.js client-only dynamic components from emitting a server-side inline bootstrap script that breaks nonce-based CSP by deferring Lightbox loading to client interaction.
- Ensure the Lightbox library is only imported in the browser when the user opens an image, avoiding SSR dynamic component bootstrap artifacts.

### Description
- Replaced `next/dynamic(..., { ssr: false })` usage with an interaction-triggered client `import("yet-another-react-lightbox")` in `app/src/components/common/display/image/image-stack.tsx` and cached the import promise to avoid repeated network cost.
- Store the loaded Lightbox component in React state and render it only after the import resolves for both `ImageStack` and `EditableImageStack` flows.
- Kept the Lightbox CSS import (`yet-another-react-lightbox/styles.css`) but removed server-side dynamic wrapper so no server-side bootstrap script is emitted.
- Verified `content-security-policy` does not require removal of any `NEXT_DYNAMIC_COMPONENT_BOOTSTRAP_SCRIPT_HASH` entry, so no CSP config/tests/docs changes were made.

### Testing
- Ran `pnpm lint app/src/components/common/display/image/image-stack.tsx` and it passed.
- Ran `pnpm format:check app/src/components/common/display/image/image-stack.tsx` and it passed.
- Ran `pnpm test app/src/infrastructures/security/content-security-policy.test.ts` and the test suite passed (3 tests, all passed).
- Attempted `pnpm build` and CI builds, which compiled and type-checked locally, but full production build/page-data inspection could not be completed in this environment due to missing local tooling (`doppler`) and required production environment variables (Sentry token, Cloudflare Access credentials), so `/ja/images` HTML verification was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307d53f0c083299ac632a46acb9025)