### PR TITLE
Propagate middleware override headers in proxy and lazily load lightbox client component

### DIFF
--- a/app/src/components/common/display/image/image-stack.tsx
+++ b/app/src/components/common/display/image/image-stack.tsx
@@ -1,17 +1,25 @@
 "use client";
 import type { DeleteAction } from "@/common/types";
+import type { LightboxExternalProps } from "yet-another-react-lightbox";
 import { DeleteButtonWithModal } from "@/components/common/forms/actions/delete-button-with-modal";
 import { StatusCodeView } from "@s-hirano-ist/s-ui/display/status/status-code-view";
 import { haptic } from "@s-hirano-ist/s-ui/utils/haptic";
 import { useTranslations } from "next-intl";
-import dynamic from "next/dynamic";
 import Image from "next/image";
 import "yet-another-react-lightbox/styles.css";
 import { useState } from "react";
 
-const Lightbox = dynamic(() => import("yet-another-react-lightbox"), {
-	ssr: false,
-});
+type LightboxComponent = React.ComponentType<LightboxExternalProps>;
+
+let lightboxPromise: Promise<LightboxComponent> | undefined;
+
+function loadLightbox(): Promise<LightboxComponent> {
+	lightboxPromise ??= import("yet-another-react-lightbox").then(
+		(module) => module.default,
+	);
+
+	return lightboxPromise;
+}
 
 export type ImageData = {
 	id?: string;
@@ -89,6 +97,8 @@ type ImageStackProps = {
 export function ImageStack({ data }: ImageStackProps) {
 	const [open, setOpen] = useState(false);
 	const [index, setIndex] = useState(0);
+	const [lightboxComponent, setLightboxComponent] =
+		useState<LightboxComponent>();
 	const t = useTranslations("statusCode");
 
 	if (data.length === 0)
@@ -101,23 +111,29 @@ export function ImageStack({ data }: ImageStackProps) {
 		alt: `Image ${image.originalPath}`,
 	}));
 
+	const Lightbox = lightboxComponent;
+
 	const handleImageClick = (imageIndex: number) => {
 		haptic();
 		setIndex(imageIndex);
-		setOpen(true);
+		void loadLightbox().then((component) => {
+			setLightboxComponent(() => component);
+			setOpen(true);
+			return null;
+		});
 	};
 
 	return (
 		<>
 			<ImageStackGrid data={data} onImageClick={handleImageClick} />
-			{open && (
+			{open && Lightbox ? (
 				<Lightbox
 					close={() => setOpen(false)}
 					index={index}
 					open={open}
 					slides={slides}
 				/>
-			)}
+			) : null}
 		</>
 	);
 }
@@ -133,6 +149,8 @@ export function EditableImageStack({
 }: EditableImageStackProps) {
 	const [open, setOpen] = useState(false);
 	const [index, setIndex] = useState(0);
+	const [lightboxComponent, setLightboxComponent] =
+		useState<LightboxComponent>();
 	const t = useTranslations("statusCode");
 
 	if (data.length === 0)
@@ -145,6 +163,8 @@ export function EditableImageStack({
 		alt: `Image ${image.originalPath}`,
 	}));
 
+	const Lightbox = lightboxComponent;
+
 	return (
 		<>
 			<ImageStackGrid
@@ -152,7 +172,11 @@ export function EditableImageStack({
 				onImageClick={(i) => {
 					setIndex(i);
 					haptic();
-					setOpen(true);
+					void loadLightbox().then((component) => {
+						setLightboxComponent(() => component);
+						setOpen(true);
+						return null;
+					});
 				}}
 				renderOverlay={(image) =>
 					image.id ? (
@@ -164,14 +188,14 @@ export function EditableImageStack({
 					) : null
 				}
 			/>
-			{open && (
+			{open && Lightbox ? (
 				<Lightbox
 					close={() => setOpen(false)}
 					index={index}
 					open={open}
 					slides={slides}
 				/>
-			)}
+			) : null}
 		</>
 	);
 }

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -61,6 +61,12 @@ describe("proxy CSP", () => {
 		expect(firstResponse.headers.get("content-security-policy")).toBe(
 			upstreamPolicy,
 		);
+		expect(
+			firstResponse.headers.get("x-middleware-request-content-security-policy"),
+		).toBe(upstreamPolicy);
+		expect(firstResponse.headers.get("x-middleware-request-x-nonce")).toBe(
+			firstNonce,
+		);
 		expect(secondResponse.headers.get("content-security-policy")).toContain(
 			`'nonce-${secondNonce}'`,
 		);

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -15,6 +15,23 @@ function addCspResponseHeader(
 	return response;
 }
 
+function addUpstreamRequestHeaders(
+	response: NextResponse,
+	requestHeaders: Headers,
+): NextResponse {
+	const upstreamResponse = NextResponse.next({
+		request: { headers: requestHeaders },
+	});
+
+	for (const [key, value] of upstreamResponse.headers) {
+		if (key !== "x-middleware-next" && key.startsWith("x-middleware-")) {
+			response.headers.set(key, value);
+		}
+	}
+
+	return response;
+}
+
 // Middleware gate: a lightweight session-cookie presence check (no DB hit, so it
 // stays edge-friendly and avoids importing the Better Auth server instance).
 // True session validation happens per-page via requireAuth()/getSelfId(), which
@@ -57,7 +74,10 @@ export default function proxy(request: NextRequest) {
 	}
 
 	return addCspResponseHeader(
-		handleI18nRouting(requestWithCsp),
+		addUpstreamRequestHeaders(
+			handleI18nRouting(requestWithCsp),
+			requestHeaders,
+		),
 		contentSecurityPolicy,
 	);
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -482,7 +482,7 @@ export default function Error({ error, reset }: ErrorPageProps) {
 
 ## Nonce CSP とレンダリング
 
-本コードベースはスクリプトのインライン実行をnonceで制限する。Proxyがリクエストごとにnonceを生成し、Next.jsはリクエストの`Content-Security-Policy`からnonceを取得してframework scriptへ付与する。
+本コードベースはスクリプトのインライン実行をnonceで制限する。Proxyがリクエストごとにnonceを生成し、Next.jsはリクエストの`Content-Security-Policy`からnonceを取得してframework scriptへ付与する。i18n middlewareなど別middlewareの`NextResponse`を返す場合も、`NextResponse.next({ request: { headers } })`相当の`x-middleware-request-*` override headersを最終レスポンスへ引き継ぎ、SSR側へnonce付きCSP request headerが届く状態を維持する。
 
 nonceはリクエストごとに異なるため、静的HTMLシェルを再利用するCache Components / PPRとは両立しない。そのため`cacheComponents`は有効化せず、ページはリクエスト時に動的レンダリングする。
 


### PR DESCRIPTION
### Motivation

- Ensure per-request nonce and enforced CSP injected by the proxy are forwarded to the final Next.js response via `x-middleware-request-*` headers so SSR receives the nonce information. 
- Prevent server-side import issues and reduce bundle impact by deferring loading of the `yet-another-react-lightbox` client component until an image is opened. 
- Update docs to describe the header propagation behavior for middleware-based `NextResponse.next({ request: { headers } })` overrides.

### Description

- Added `addUpstreamRequestHeaders` in `proxy.ts` to copy `x-middleware-*` override headers (excluding `x-middleware-next`) from a `NextResponse.next` upstream response into the final response. 
- Wired `addUpstreamRequestHeaders` into the proxy return path so the enforced `Content-Security-Policy` and `x-nonce` provided upstream are exposed as `x-middleware-request-content-security-policy` and `x-middleware-request-x-nonce` on the response. 
- Refactored `ImageStack`/`EditableImageStack` in `image-stack.tsx` to remove `next/dynamic` and implement a cached `loadLightbox()` dynamic import that sets a `LightboxComponent` state and only renders the lightbox after it is loaded. 
- Updated `proxy.test.ts` to assert the presence of the propagated `x-middleware-request-*` headers, and adjusted test flows accordingly. 
- Revised `docs/architecture.md` to document the propagation of `x-middleware-request-*` override headers for SSR/CSP nonce delivery.

### Testing

- Ran the unit test suite including the updated `proxy.test.ts` which asserts propagated `x-middleware-request-content-security-policy` and `x-middleware-request-x-nonce`, and the tests succeeded. 
- Verified that image lightbox behavior loads the client component lazily at runtime via the new `loadLightbox()` path during interactive use (manually exercised during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307d53f0c083299ac632a46acb9025)