### PR TITLE
Lazy-load sharp via dynamic import in sharp-image-processor

### DIFF
--- a/app/src/infrastructures/images/services/sharp-image-processor.ts
+++ b/app/src/infrastructures/images/services/sharp-image-processor.ts
@@ -12,7 +12,17 @@ import type {
 	IImageProcessor,
 	ImageMetadata,
 } from "@s-hirano-ist/s-core/images/services/image-processor.interface";
-import sharp from "sharp";
+import type sharp from "sharp";
+
+type SharpFactory = typeof sharp;
+
+let sharpFactoryPromise: Promise<SharpFactory> | undefined;
+
+async function loadSharp(): Promise<SharpFactory> {
+	sharpFactoryPromise ??= import("sharp").then((module) => module.default);
+
+	return sharpFactoryPromise;
+}
 
 /**
  * Default thumbnail width in pixels.
@@ -31,10 +41,12 @@ async function createThumbnail(
 	width: number = THUMBNAIL_WIDTH,
 	height: number = THUMBNAIL_HEIGHT,
 ): Promise<Buffer> {
+	const sharp = await loadSharp();
 	return await sharp(buffer).resize(width, height).toBuffer();
 }
 
 async function getMetadata(buffer: Buffer): Promise<ImageMetadata> {
+	const sharp = await loadSharp();
 	const metadata = await sharp(buffer).metadata();
 	return {
 		width: metadata.width,


### PR DESCRIPTION
### Motivation

- Avoid eager/native `sharp` import at module load time to reduce startup cost and prevent environment/bundler issues by deferring heavy native initialization.

### Description

- Replace static `import sharp from "sharp"` with a type-only import and add a `loadSharp` function that lazily imports `sharp` using `import("sharp").then(m => m.default)` and caches the promise in `sharpFactoryPromise`.
- Introduce `SharpFactory` type and update `createThumbnail` and `getMetadata` to call `await loadSharp()` before using `sharp` so behavior stays the same while loading is deferred.
- Keep `fileToBuffer` and exported `sharpImageProcessor` API unchanged.

### Testing

- Ran the project test suite with `npm test`; unit tests related to image processing passed.
- Ran TypeScript type check with `tsc --noEmit`; the build type check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308ce559988329bace4c9d3f85febe)