### PR TITLE
Apply upstream middleware headers to unauthenticated redirects

### DIFF
--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -84,9 +84,18 @@ describe("proxy CSP", () => {
 		expect(response.headers.get("location")).toBe(
 			"https://example.com/api/sign-in",
 		);
-		expect(response.headers.get("content-security-policy")).toContain(
-			"'nonce-",
+		const contentSecurityPolicy = response.headers.get(
+			"content-security-policy",
 		);
+		const upstreamContentSecurityPolicy = response.headers.get(
+			"x-middleware-request-content-security-policy",
+		);
+		const upstreamNonce = response.headers.get("x-middleware-request-x-nonce");
+
+		expect(contentSecurityPolicy).toContain("'nonce-");
+		expect(upstreamNonce).toBeTruthy();
+		expect(upstreamContentSecurityPolicy).toBe(contentSecurityPolicy);
+		expect(upstreamContentSecurityPolicy).toContain(`'nonce-${upstreamNonce}'`);
 		expect(
 			response.headers.get("content-security-policy-report-only"),
 		).toBeNull();

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -68,7 +68,10 @@ export default function proxy(request: NextRequest) {
 	const sessionCookie = getSessionCookie(requestWithCsp);
 	if (!sessionCookie) {
 		return addCspResponseHeader(
-			NextResponse.redirect(new URL("/api/sign-in", request.url)),
+			addUpstreamRequestHeaders(
+				NextResponse.redirect(new URL("/api/sign-in", request.url)),
+				requestHeaders,
+			),
 			contentSecurityPolicy,
 		);
 	}


### PR DESCRIPTION
### Motivation
- Ensure unauthenticated redirect responses receive the same upstream middleware request headers (nonce and enforced CSP) as the authenticated branch so SSR nonce enforcement and CSP propagation remain consistent.

### Description
- Update `app/src/proxy.ts` to pass the `NextResponse.redirect(...)` through `addUpstreamRequestHeaders(..., requestHeaders)` before applying `addCspResponseHeader`.
- Update `app/src/proxy.test.ts` test `adds enforced CSP to unauthenticated redirects` to assert the presence of `x-middleware-request-x-nonce` and `x-middleware-request-content-security-policy` and that the upstream CSP matches the response `Content-Security-Policy` while keeping the existing CSP checks.

### Testing
- Ran `pnpm exec vitest run app/src/proxy.test.ts`, which passed (tests succeeded).
- Ran `pnpm lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3290d328f08329ad77c89dcd53c8ce)