### PR TITLE
[codex] fix vercel storage dump logging

### DIFF
--- a/app/src/app/api/internal/cache/invalidate/route.ts
+++ b/app/src/app/api/internal/cache/invalidate/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: Request): Promise<Response> {
 
 		return Response.json({ invalidated: tags.length });
 	} catch (error) {
-		serverLogger.error(
+		await serverLogger.error(
 			"Failed to invalidate content cache",
 			{
 				caller: "POST /api/internal/cache/invalidate",

--- a/app/src/application-services/books/add-books.core.ts
+++ b/app/src/application-services/books/add-books.core.ts
@@ -12,6 +12,7 @@ import type { AddBooksDeps } from "./add-books.deps";
 import type { ServerAction } from "@/common/types";
 import { getSelfId } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
+import { withStoragePhase } from "@/common/error/storage-phase-error";
 import { bookEntity } from "@s-hirano-ist/s-core/books/entities/book-entity";
 import { parseAddBooksFormData } from "./helpers/form-data-parser";
 
@@ -47,19 +48,43 @@ export async function addBooksCore(
 			parsedData.userId,
 		);
 
+		const storageContext = {
+			action: "addBooks",
+			path: parsedData.path,
+			fileSize: parsedData.fileSize,
+			contentType: parsedData.contentType,
+			isbn: parsedData.isbn,
+		};
+
 		// Upload image to MinIO (original + thumbnail)
-		await Promise.all([
-			storageService.uploadImage(
-				parsedData.path,
-				parsedData.originalBuffer,
-				false,
-			),
-			storageService.uploadImage(
-				parsedData.path,
-				parsedData.thumbnailBuffer,
-				true,
-			),
-		]);
+		await withStoragePhase(
+			{
+				phase: "upload-original",
+				path: parsedData.path,
+				isThumbnail: false,
+				additionalContext: storageContext,
+			},
+			() =>
+				storageService.uploadImage(
+					parsedData.path,
+					parsedData.originalBuffer,
+					false,
+				),
+		);
+		await withStoragePhase(
+			{
+				phase: "upload-thumbnail",
+				path: parsedData.path,
+				isThumbnail: true,
+				additionalContext: storageContext,
+			},
+			() =>
+				storageService.uploadImage(
+					parsedData.path,
+					parsedData.thumbnailBuffer,
+					true,
+				),
+		);
 
 		// Create entity with value objects and domain event
 		const [book, event] = bookEntity.create({

--- a/app/src/application-services/books/add-books.test.ts
+++ b/app/src/application-services/books/add-books.test.ts
@@ -196,6 +196,22 @@ describe("addBooksCore", () => {
 		});
 	});
 
+	test("should return storageError when book cover upload fails", async () => {
+		vi.mocked(getSelfId).mockResolvedValue(makeUserId("user-123"));
+
+		const { deps, mockCommandRepository, mockStorageService } =
+			createMockDeps();
+		vi.mocked(mockStorageService.uploadImage).mockRejectedValueOnce(
+			new Error("Cloudflare Access denied"),
+		);
+
+		const result = await addBooksCore(mockFormData, deps);
+
+		expect(mockStorageService.uploadImage).toHaveBeenCalledTimes(1);
+		expect(mockCommandRepository.create).not.toHaveBeenCalled();
+		expect(result).toEqual({ success: false, message: "storageError" });
+	});
+
 	test("should handle unexpected errors", async () => {
 		vi.mocked(getSelfId).mockResolvedValue(makeUserId("user-123"));
 

--- a/app/src/application-services/images/add-image.core.ts
+++ b/app/src/application-services/images/add-image.core.ts
@@ -12,6 +12,7 @@ import type { AddImageDeps } from "./add-image.deps";
 import type { ServerAction } from "@/common/types";
 import { getSelfId } from "@/common/auth/session";
 import { wrapServerSideErrorForClient } from "@/common/error/error-wrapper";
+import { withStoragePhase } from "@/common/error/storage-phase-error";
 import { imageEntity } from "@s-hirano-ist/s-core/images/entities/image-entity";
 import { parseAddImageFormData } from "./helpers/form-data-parser";
 
@@ -60,10 +61,31 @@ export async function addImageCore(
 			caller: "addImage",
 		});
 
-		await Promise.all([
-			storageService.uploadImage(image.path, originalBuffer, false),
-			storageService.uploadImage(image.path, thumbnailBuffer, true),
-		]);
+		const storageContext = {
+			action: "addImage",
+			path,
+			fileSize,
+			contentType,
+		};
+
+		await withStoragePhase(
+			{
+				phase: "upload-original",
+				path: image.path,
+				isThumbnail: false,
+				additionalContext: storageContext,
+			},
+			() => storageService.uploadImage(image.path, originalBuffer, false),
+		);
+		await withStoragePhase(
+			{
+				phase: "upload-thumbnail",
+				path: image.path,
+				isThumbnail: true,
+				additionalContext: storageContext,
+			},
+			() => storageService.uploadImage(image.path, thumbnailBuffer, true),
+		);
 		// Cache invalidation is handled in repository
 		await commandRepository.create(image);
 

--- a/app/src/application-services/images/add-image.test.ts
+++ b/app/src/application-services/images/add-image.test.ts
@@ -137,6 +137,39 @@ describe("addImageCore", () => {
 		});
 	});
 
+	test("should return storageError when storage upload fails", async () => {
+		const validFileType = "image/jpeg";
+		const validFileSize = 1_700_000;
+		const file = createMockFile("myImage.jpeg", validFileType, validFileSize);
+		mockFormData = new FormData();
+		mockFormData.append("file", file);
+
+		vi.mocked(getSelfId).mockResolvedValue(makeUserId("user-id"));
+		vi.mocked(parseAddImageFormData).mockResolvedValue({
+			userId: makeUserId("user-id"),
+			path: "myImage.jpeg" as Path,
+			contentType: "image/jpeg" as ContentType,
+			fileSize: validFileSize as FileSize,
+			originalBuffer: Buffer.from([]),
+			thumbnailBuffer: Buffer.from([]),
+		});
+
+		const { deps, mockCommandRepository, mockStorageService } =
+			createMockDeps();
+		vi.mocked(mockStorageService.uploadImage).mockRejectedValueOnce(
+			new Error("Cloudflare Access denied"),
+		);
+
+		const result = await addImageCore(mockFormData, deps);
+
+		expect(mockStorageService.uploadImage).toHaveBeenCalledTimes(1);
+		expect(mockCommandRepository.create).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			success: false,
+			message: "storageError",
+		});
+	});
+
 	test("should return success false on invalid file type", async () => {
 		const validFileType = "invalid";
 		const validFileSize = 1024 * 1024;

--- a/app/src/common/error/error-wrapper.test.ts
+++ b/app/src/common/error/error-wrapper.test.ts
@@ -29,6 +29,19 @@ vi.mock("@s-hirano-ist/s-storage", () => ({
 			this.name = "S3Error";
 		}
 	},
+	StorageOperationError: class MockStorageOperationError extends Error {
+		context: Record<string, unknown>;
+		constructor(context: Record<string, unknown>, cause: unknown) {
+			super(
+				`Storage ${String(context.operation)} failed for ${String(context.objectKey)}`,
+				{
+					cause,
+				},
+			);
+			this.name = "StorageOperationError";
+			this.context = context;
+		}
+	},
 }));
 
 describe("wrapServerSideErrorForClient", () => {
@@ -283,6 +296,46 @@ describe("wrapServerSideErrorForClient", () => {
 				metadata: expect.objectContaining({
 					caller: "wrapServerSideError",
 					userId: "system",
+				}),
+			}),
+		);
+		expect(result).toEqual({
+			success: false,
+			message: "storageError",
+		});
+	});
+
+	test("should handle StorageOperationError", async () => {
+		const { StorageOperationError } = await import("@s-hirano-ist/s-storage");
+		const cause = new Error("Cloudflare Access denied");
+		const error = new StorageOperationError(
+			{
+				operation: "uploadImage",
+				objectKey: "images/original/image.jpg",
+				bucketName: "bucket",
+				isThumbnail: false,
+				phase: "upload-original",
+				additionalContext: { action: "addImage", fileSize: 1_700_000 },
+			},
+			cause,
+		);
+
+		const result = await wrapServerSideErrorForClient(error);
+
+		expect(eventDispatcher.dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "system.error",
+				payload: expect.objectContaining({
+					message: "Storage uploadImage failed for images/original/image.jpg",
+					status: 500,
+					extraData: expect.objectContaining({
+						storage: expect.objectContaining({
+							phase: "upload-original",
+							objectKey: "images/original/image.jpg",
+						}),
+						cause,
+					}),
+					shouldNotify: true,
 				}),
 			}),
 		);

--- a/app/src/common/error/error-wrapper.ts
+++ b/app/src/common/error/error-wrapper.ts
@@ -22,7 +22,7 @@ import { SystemErrorEvent } from "@s-hirano-ist/s-core/shared-kernel/events/syst
 import { SystemWarningEvent } from "@s-hirano-ist/s-core/shared-kernel/events/system-warning-event";
 import { Prisma } from "@s-hirano-ist/s-database";
 import { NotificationError } from "@s-hirano-ist/s-notification";
-import { S3Error } from "@s-hirano-ist/s-storage";
+import { S3Error, StorageOperationError } from "@s-hirano-ist/s-storage";
 import { APIError } from "better-auth/api";
 import { ZodError } from "zod";
 
@@ -63,6 +63,21 @@ async function handleNotificationOrS3Error(
 		);
 		return { success: false, message: error.message };
 	}
+	if (error instanceof StorageOperationError) {
+		await eventDispatcher.dispatch(
+			new SystemErrorEvent({
+				message: error.message,
+				status: 500,
+				caller: "wrapServerSideError",
+				extraData: {
+					storage: error.context,
+					cause: error.cause,
+				},
+				shouldNotify: true,
+			}),
+		);
+		return { success: false, message: "storageError" };
+	}
 	// MinIO S3 server errors
 	if (error instanceof S3Error) {
 		await eventDispatcher.dispatch(
@@ -70,6 +85,7 @@ async function handleNotificationOrS3Error(
 				message: `MinIO S3 Error: ${error.code} - ${error.message}`,
 				status: 500,
 				caller: "wrapServerSideError",
+				extraData: error,
 				shouldNotify: true,
 			}),
 		);
@@ -197,6 +213,7 @@ async function handleUnexpectedError(error: unknown): Promise<ServerAction> {
 				message: error.message,
 				status: 500,
 				caller: "wrapServerSideError",
+				extraData: error,
 				shouldNotify: true,
 			}),
 		);

--- a/app/src/common/error/storage-phase-error.ts
+++ b/app/src/common/error/storage-phase-error.ts
@@ -1,0 +1,40 @@
+import { StorageOperationError } from "@s-hirano-ist/s-storage";
+
+type StoragePhaseContext = {
+	phase: string;
+	path: string;
+	isThumbnail: boolean;
+	additionalContext?: Record<string, unknown>;
+};
+
+export async function withStoragePhase<T>(
+	context: StoragePhaseContext,
+	operation: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await operation();
+	} catch (error) {
+		if (error instanceof StorageOperationError) {
+			throw new StorageOperationError(
+				{
+					...error.context,
+					phase: context.phase,
+					additionalContext: context.additionalContext,
+				},
+				error.cause ?? error,
+			);
+		}
+
+		throw new StorageOperationError(
+			{
+				operation: "uploadImage",
+				objectKey: context.path,
+				bucketName: "unknown",
+				isThumbnail: context.isThumbnail,
+				phase: context.phase,
+				additionalContext: context.additionalContext,
+			},
+			error,
+		);
+	}
+}

--- a/app/src/infrastructures/events/handlers/logging-event-handler.ts
+++ b/app/src/infrastructures/events/handlers/logging-event-handler.ts
@@ -43,7 +43,7 @@ export class LoggingEventHandler implements DomainEventHandler {
 
 		const status = eventType.includes("created") ? 201 : 200;
 
-		serverLogger.info(
+		await serverLogger.info(
 			message,
 			{
 				caller: metadata.caller,

--- a/app/src/infrastructures/events/handlers/system-event-handler.ts
+++ b/app/src/infrastructures/events/handlers/system-event-handler.ts
@@ -21,10 +21,14 @@ export class SystemEventHandler implements DomainEventHandler {
 
 		switch (eventType) {
 			case "system.warning":
-				serverLogger.warn(payload.message as string, context, notifyOptions);
+				await serverLogger.warn(
+					payload.message as string,
+					context,
+					notifyOptions,
+				);
 				break;
 			case "system.error":
-				serverLogger.error(
+				await serverLogger.error(
 					payload.message as string,
 					context,
 					payload.extraData,

--- a/app/src/infrastructures/observability/logging/logger.interface.ts
+++ b/app/src/infrastructures/observability/logging/logger.interface.ts
@@ -12,12 +12,20 @@ export type LogOptions = {
 };
 
 export type Logger = {
-	info(message: string, context: LogContext, options?: LogOptions): void;
-	warn(message: string, context: LogContext, options?: LogOptions): void;
+	info(
+		message: string,
+		context: LogContext,
+		options?: LogOptions,
+	): Promise<void>;
+	warn(
+		message: string,
+		context: LogContext,
+		options?: LogOptions,
+	): Promise<void>;
 	error(
 		message: string,
 		context: LogContext,
 		error?: unknown,
 		options?: LogOptions,
-	): void;
+	): Promise<void>;
 };

--- a/app/src/infrastructures/observability/logging/server-logger.ts
+++ b/app/src/infrastructures/observability/logging/server-logger.ts
@@ -17,21 +17,29 @@ export class ServerLogger implements Logger {
 		this.notificationService = notificationService;
 	}
 
-	info(message: string, context: LogContext, options?: LogOptions): void {
-		void this.logWithLevel("info", message, context, undefined, options);
+	async info(
+		message: string,
+		context: LogContext,
+		options?: LogOptions,
+	): Promise<void> {
+		await this.logWithLevel("info", message, context, undefined, options);
 	}
 
-	warn(message: string, context: LogContext, options?: LogOptions): void {
-		void this.logWithLevel("warn", message, context, undefined, options);
+	async warn(
+		message: string,
+		context: LogContext,
+		options?: LogOptions,
+	): Promise<void> {
+		await this.logWithLevel("warn", message, context, undefined, options);
 	}
 
-	error(
+	async error(
 		message: string,
 		context: LogContext,
 		error?: unknown,
 		options?: LogOptions,
-	): void {
-		void this.logWithLevel("error", message, context, error, options);
+	): Promise<void> {
+		await this.logWithLevel("error", message, context, error, options);
 	}
 
 	private async logWithLevel(

--- a/app/src/infrastructures/shared/storage/minio-storage-service.test.ts
+++ b/app/src/infrastructures/shared/storage/minio-storage-service.test.ts
@@ -1,4 +1,5 @@
 import { minioClient } from "@/minio";
+import { StorageOperationError } from "@s-hirano-ist/s-storage";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { minioStorageService } from "./minio-storage-service";
@@ -53,9 +54,17 @@ describe("MinioStorageService", () => {
 				new Error("Storage upload failed"),
 			);
 
-			await expect(
-				minioStorageService.uploadImage(path, buffer, false),
-			).rejects.toThrow("Storage upload failed");
+			const upload = minioStorageService.uploadImage(path, buffer, false);
+
+			await expect(upload).rejects.toThrow(StorageOperationError);
+			await expect(upload).rejects.toMatchObject({
+				context: {
+					operation: "uploadImage",
+					bucketName: "test-bucket",
+					objectKey: `images/original/${path}`,
+					isThumbnail: false,
+				},
+			});
 
 			expect(minioClient.putObject).toHaveBeenCalledWith(
 				"test-bucket",
@@ -104,7 +113,7 @@ describe("MinioStorageService", () => {
 			);
 
 			await expect(minioStorageService.getImage(path, false)).rejects.toThrow(
-				"Object not found",
+				StorageOperationError,
 			);
 
 			expect(minioClient.getObject).toHaveBeenCalledWith(
@@ -142,7 +151,7 @@ describe("MinioStorageService", () => {
 
 			await expect(
 				minioStorageService.getImageOrThrow(path, false),
-			).rejects.toThrow("Object not found");
+			).rejects.toThrow(StorageOperationError);
 		});
 	});
 
@@ -182,7 +191,7 @@ describe("MinioStorageService", () => {
 
 			await expect(
 				minioStorageService.deleteImage(path, false),
-			).rejects.toThrow("Delete failed");
+			).rejects.toThrow(StorageOperationError);
 		});
 	});
 });

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -1,7 +1,9 @@
 export { S3Error } from "minio";
 export { createCfAccessTransport } from "./src/cf-access-transport.ts";
 export { createMinioClient } from "./src/client.ts";
+export { StorageOperationError } from "./src/errors.ts";
 export { createStorageService } from "./src/storage-service.ts";
+export type { StorageOperationContext } from "./src/errors.ts";
 export type {
 	CfAccessConfig,
 	MinioClient,

--- a/packages/storage/src/errors.ts
+++ b/packages/storage/src/errors.ts
@@ -1,0 +1,20 @@
+export type StorageOperationContext = {
+	operation: "uploadImage" | "getImage" | "getImageOrThrow" | "deleteImage";
+	objectKey: string;
+	bucketName: string;
+	isThumbnail?: boolean;
+	phase?: string;
+	additionalContext?: Record<string, unknown>;
+};
+
+export class StorageOperationError extends Error {
+	readonly context: StorageOperationContext;
+
+	constructor(context: StorageOperationContext, cause: unknown) {
+		super(`Storage ${context.operation} failed for ${context.objectKey}`, {
+			cause,
+		});
+		this.name = "StorageOperationError";
+		this.context = context;
+	}
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,7 +1,9 @@
 export { S3Error } from "minio";
 export { createCfAccessTransport } from "./cf-access-transport.ts";
 export { createMinioClient } from "./client.ts";
+export { StorageOperationError } from "./errors.ts";
 export { createStorageService } from "./storage-service.ts";
+export type { StorageOperationContext } from "./errors.ts";
 export type {
 	CfAccessConfig,
 	MinioClient,

--- a/packages/storage/src/storage-service.ts
+++ b/packages/storage/src/storage-service.ts
@@ -1,5 +1,9 @@
 import type { StoragePathConfig, StorageServiceOperations } from "./types.ts";
 import type { Client } from "minio";
+import {
+	type StorageOperationContext,
+	StorageOperationError,
+} from "./errors.ts";
 
 export function createStorageService(
 	client: Client,
@@ -10,6 +14,18 @@ export function createStorageService(
 		return `${isThumbnail ? pathConfig.thumbnailPrefix : pathConfig.originalPrefix}/${path}`;
 	}
 
+	function wrapStorageError(
+		operation: StorageOperationContext["operation"],
+		objectKey: string,
+		isThumbnail: boolean | undefined,
+		error: unknown,
+	): never {
+		throw new StorageOperationError(
+			{ operation, objectKey, bucketName, isThumbnail },
+			error,
+		);
+	}
+
 	return {
 		async uploadImage(
 			path: string,
@@ -17,7 +33,11 @@ export function createStorageService(
 			isThumbnail: boolean,
 		): Promise<void> {
 			const objKey = buildObjectKey(path, isThumbnail);
-			await client.putObject(bucketName, objKey, buffer);
+			try {
+				await client.putObject(bucketName, objKey, buffer);
+			} catch (error) {
+				wrapStorageError("uploadImage", objKey, isThumbnail, error);
+			}
 		},
 
 		async getImage(
@@ -25,17 +45,29 @@ export function createStorageService(
 			isThumbnail: boolean,
 		): Promise<NodeJS.ReadableStream> {
 			const objKey = buildObjectKey(path, isThumbnail);
-			return await client.getObject(bucketName, objKey);
+			try {
+				return await client.getObject(bucketName, objKey);
+			} catch (error) {
+				return wrapStorageError("getImage", objKey, isThumbnail, error);
+			}
 		},
 
 		async getImageOrThrow(path: string, isThumbnail: boolean): Promise<void> {
 			const objKey = buildObjectKey(path, isThumbnail);
-			await client.statObject(bucketName, objKey);
+			try {
+				await client.statObject(bucketName, objKey);
+			} catch (error) {
+				wrapStorageError("getImageOrThrow", objKey, isThumbnail, error);
+			}
 		},
 
 		async deleteImage(path: string, isThumbnail: boolean): Promise<void> {
 			const objKey = buildObjectKey(path, isThumbnail);
-			await client.removeObject(bucketName, objKey);
+			try {
+				await client.removeObject(bucketName, objKey);
+			} catch (error) {
+				wrapStorageError("deleteImage", objKey, isThumbnail, error);
+			}
 		},
 	};
 }


### PR DESCRIPTION
## Summary

- Classify MinIO/Cloudflare Tunnel upload failures as storage errors instead of generic unexpected errors.
- Add storage phase context for image and book dumps so failures identify original vs thumbnail upload.
- Await server logging paths so Vercel functions do not exit before logs or notifications are emitted.

## Root Cause

Image and book dump paths both upload files through MinIO from Vercel server code. Non-S3 or tunnel-related failures could be wrapped as generic unexpected errors, and the logger was fire-and-forget, making production failures hard to observe.

## Validation

- `pnpm --filter s-private-app typecheck`
- `pnpm --filter @s-hirano-ist/s-storage typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm deps:check` (existing no-orphans warnings only)
- Targeted Vitest: 60 passed
- `pnpm test`: 932 passed