### PR TITLE
[codex] fix storage error i18n fallback

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -54,6 +54,7 @@
 		"updated": "Updated successfully.",
 		"unexpected": "Unexpected error occurred.",
 		"pushoverSend": "Failed to send logs.",
+		"storageError": "Failed to upload to storage.",
 		"duplicated": "Duplicated record.",
 		"prismaUnexpected": "Failed to write to database.",
 		"unauthorized": "Unauthorized error.",

--- a/app/messages/ja.json
+++ b/app/messages/ja.json
@@ -54,6 +54,7 @@
 		"updated": "更新が完了しました。",
 		"unexpected": "予期せぬエラーが発生しました。",
 		"pushoverSend": "ログの送信でエラーが発生しました。",
+		"storageError": "ストレージへのアップロードに失敗しました。",
 		"duplicated": "すでに登録されているため登録できません。",
 		"prismaUnexpected": "データベースへの書き込み時にエラーが発生しました。",
 		"unauthorized": "認証されていません。",

--- a/app/src/app/[locale]/layout.tsx
+++ b/app/src/app/[locale]/layout.tsx
@@ -2,11 +2,11 @@ import { searchContentFromClient } from "@/application-services/search/search-co
 import { resolveContentSecurityPolicyNonce } from "@/common/security/content-security-policy-nonce";
 import { Footer } from "@/components/common/layouts/nav/footer";
 import { env } from "@/env";
+import { IntlClientProvider } from "@/infrastructures/i18n/client-provider";
 import { routing } from "@/infrastructures/i18n/routing";
 import Loading from "@s-hirano-ist/s-ui/display/loading";
 import { ThemeProvider } from "@s-hirano-ist/s-ui/providers/theme-provider";
 import { Toaster } from "@s-hirano-ist/s-ui/ui/toast";
-import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
@@ -33,7 +33,7 @@ async function LocaleLayoutContent({ children, params }: Params) {
 	);
 
 	return (
-		<NextIntlClientProvider messages={messages}>
+		<IntlClientProvider locale={locale} messages={messages}>
 			<ThemeProvider
 				attribute="class"
 				defaultTheme="system"
@@ -47,7 +47,7 @@ async function LocaleLayoutContent({ children, params }: Params) {
 				</main>
 				<Toaster />
 			</ThemeProvider>
-		</NextIntlClientProvider>
+		</IntlClientProvider>
 	);
 }
 

--- a/app/src/infrastructures/i18n/client-provider.tsx
+++ b/app/src/infrastructures/i18n/client-provider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { AbstractIntlMessages } from "next-intl";
+import type { ReactNode } from "react";
+import { IntlErrorCode, NextIntlClientProvider } from "next-intl";
+
+type Props = {
+	children: ReactNode;
+	locale: string;
+	messages: AbstractIntlMessages;
+};
+
+function getGenericMessage(messages: AbstractIntlMessages): string {
+	const messageNamespace = messages.message;
+
+	if (messageNamespace && typeof messageNamespace === "object") {
+		const errorMessage = messageNamespace.error;
+
+		if (typeof errorMessage === "string") {
+			return errorMessage;
+		}
+	}
+
+	return "An error occurred.";
+}
+
+export function IntlClientProvider({ children, locale, messages }: Props) {
+	const genericMessage = getGenericMessage(messages);
+
+	return (
+		<NextIntlClientProvider
+			getMessageFallback={({ error, key, namespace }) => {
+				if (
+					error.code === IntlErrorCode.MISSING_MESSAGE &&
+					namespace === "message"
+				) {
+					return genericMessage;
+				}
+
+				return namespace ? `${namespace}.${key}` : key;
+			}}
+			locale={locale}
+			messages={messages}
+		>
+			{children}
+		</NextIntlClientProvider>
+	);
+}


### PR DESCRIPTION
## Summary

- Add `storageError` messages for Japanese and English so storage failures render as user-facing toast text.
- Wrap `NextIntlClientProvider` with a client-side fallback provider so missing `message.*` keys do not crash the page.

## Context

The server action returns HTTP 200 with `{ success: false, message: "storageError" }`. Without a matching translation key, the client can throw during toast rendering and then route into the protected `/error` flow, matching the observed 307 `/error` → `/api/sign-in` chain.

## Validation

- `pnpm --filter s-private-app typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test -- --project app app/src/common/error/error-wrapper.test.ts app/src/application-services/images/add-image.test.ts app/src/application-services/books/add-books.test.ts` (932 passed)