### PR TITLE
[codex] fix dumper image format detection

### DIFF
--- a/app/src/application-services/books/helpers/form-data-parser.test.ts
+++ b/app/src/application-services/books/helpers/form-data-parser.test.ts
@@ -61,6 +61,7 @@ vi.mock(
 vi.mock("@/infrastructures/images/services/sharp-image-processor", () => ({
 	sharpImageProcessor: {
 		fileToBuffer: vi.fn(),
+		getMetadata: vi.fn(),
 		createThumbnail: vi.fn(),
 	},
 }));
@@ -75,6 +76,7 @@ const mockMakePath = vi.mocked(makePath);
 const mockMakeContentType = vi.mocked(makeContentType);
 const mockMakeFileSize = vi.mocked(makeFileSize);
 const mockFileToBuffer = vi.mocked(sharpImageProcessor.fileToBuffer);
+const mockGetMetadata = vi.mocked(sharpImageProcessor.getMetadata);
 const mockCreateThumbnail = vi.mocked(sharpImageProcessor.createThumbnail);
 
 const buildMockFile = (
@@ -95,6 +97,7 @@ describe("parseAddBooksFormData", () => {
 		mockMakeContentType.mockImplementation((v) => v as ContentType);
 		mockMakeFileSize.mockImplementation((v) => v as FileSize);
 		mockFileToBuffer.mockResolvedValue(Buffer.from([1, 2, 3]));
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockResolvedValue(Buffer.from([4, 5, 6]));
 	});
 
@@ -272,7 +275,27 @@ describe("parseAddBooksFormData", () => {
 		expect(result.userId).toBe("different-user-123");
 	});
 
-	test("should reject unsupported cover image content type before reading file", async () => {
+	test("should accept cover image when browser does not provide content type", async () => {
+		const formData = new FormData();
+		const userId = "test-user-id" as UserId;
+
+		mockGetFormDataString
+			.mockReturnValueOnce("9784123456789")
+			.mockReturnValueOnce("Clean Code")
+			.mockReturnValueOnce("5")
+			.mockReturnValueOnce("programming");
+		mockGetFormDataFile.mockReturnValueOnce(buildMockFile("cover.jpg", ""));
+		mockMakeISBN.mockReturnValue("9784123456789" as ISBN);
+		mockMakeBookTitle.mockReturnValue("Clean Code" as BookTitle);
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
+
+		const result = await parseAddBooksFormData(formData, userId);
+
+		expect(mockMakeContentType).toHaveBeenCalledWith("image/jpeg");
+		expect(result.contentType).toBe("image/jpeg");
+	});
+
+	test("should reject unsupported cover image format after reading metadata", async () => {
 		const formData = new FormData();
 		const userId = "test-user-id" as UserId;
 
@@ -284,11 +307,52 @@ describe("parseAddBooksFormData", () => {
 		mockGetFormDataFile.mockReturnValueOnce(
 			buildMockFile("cover.avif", "image/avif"),
 		);
+		mockGetMetadata.mockResolvedValue({ format: "avif" });
 
 		await expect(parseAddBooksFormData(formData, userId)).rejects.toThrow(
 			FileNotAllowedError,
 		);
-		expect(mockFileToBuffer).not.toHaveBeenCalled();
+		expect(mockFileToBuffer).toHaveBeenCalled();
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject cover image when metadata format is missing", async () => {
+		const formData = new FormData();
+		const userId = "test-user-id" as UserId;
+
+		mockGetFormDataString
+			.mockReturnValueOnce("9784123456789")
+			.mockReturnValueOnce("Clean Code")
+			.mockReturnValueOnce("5")
+			.mockReturnValueOnce("programming");
+		mockGetFormDataFile.mockReturnValueOnce(buildMockFile("cover.jpg", ""));
+		mockGetMetadata.mockResolvedValue({});
+
+		await expect(parseAddBooksFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject cover images sharp cannot read metadata from", async () => {
+		const formData = new FormData();
+		const userId = "test-user-id" as UserId;
+
+		mockGetFormDataString
+			.mockReturnValueOnce("9784123456789")
+			.mockReturnValueOnce("Clean Code")
+			.mockReturnValueOnce("5")
+			.mockReturnValueOnce("programming");
+		mockGetFormDataFile.mockReturnValueOnce(
+			buildMockFile("cover.jpg", "image/jpeg"),
+		);
+		mockGetMetadata.mockRejectedValue(
+			new Error("Input buffer has corrupt header"),
+		);
+
+		await expect(parseAddBooksFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
 		expect(mockCreateThumbnail).not.toHaveBeenCalled();
 	});
 

--- a/app/src/application-services/books/helpers/form-data-parser.ts
+++ b/app/src/application-services/books/helpers/form-data-parser.ts
@@ -5,6 +5,7 @@
  */
 
 import type { UserId } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
+import { parseSupportedImageFile } from "@/application-services/common/image-upload-parser";
 import {
 	getFormDataFile,
 	getFormDataString,
@@ -22,19 +23,6 @@ import {
 	makePath,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/file-entity";
 import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
-
-const SUPPORTED_IMAGE_TYPES = new Set([
-	"image/jpeg",
-	"image/png",
-	"image/gif",
-	"image/webp",
-]);
-
-function assertSupportedImageType(contentType: string): void {
-	if (!SUPPORTED_IMAGE_TYPES.has(contentType)) {
-		throw new FileNotAllowedError();
-	}
-}
 
 async function createThumbnailOrThrowInvalidFile(
 	buffer: Buffer,
@@ -68,11 +56,11 @@ export const parseAddBooksFormData = async (
 		.map((t) => t.trim())
 		.filter((t) => t.length > 0);
 
-	assertSupportedImageType(file.type);
+	const { contentType: detectedContentType, originalBuffer } =
+		await parseSupportedImageFile(file);
 	const path = makePath(file.name, true);
-	const contentType = makeContentType(file.type);
+	const contentType = makeContentType(detectedContentType);
 	const fileSize = makeFileSize(file.size);
-	const originalBuffer = await sharpImageProcessor.fileToBuffer(file);
 	const thumbnailBuffer =
 		await createThumbnailOrThrowInvalidFile(originalBuffer);
 

--- a/app/src/application-services/common/image-upload-parser.ts
+++ b/app/src/application-services/common/image-upload-parser.ts
@@ -1,0 +1,43 @@
+import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
+import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
+
+const SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE = new Map<string, string>([
+	["jpeg", "image/jpeg"],
+	["png", "image/png"],
+	["gif", "image/gif"],
+	["webp", "image/webp"],
+]);
+
+function toSupportedImageContentType(format: string | undefined): string {
+	if (format === undefined) {
+		throw new FileNotAllowedError();
+	}
+
+	const contentType = SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE.get(format);
+
+	if (contentType === undefined) {
+		throw new FileNotAllowedError();
+	}
+
+	return contentType;
+}
+
+export async function parseSupportedImageFile(file: File): Promise<{
+	contentType: string;
+	originalBuffer: Buffer;
+}> {
+	const originalBuffer = await sharpImageProcessor.fileToBuffer(file);
+
+	try {
+		const metadata = await sharpImageProcessor.getMetadata(originalBuffer);
+		const contentType = toSupportedImageContentType(metadata.format);
+
+		return { contentType, originalBuffer };
+	} catch (error) {
+		if (error instanceof FileNotAllowedError) {
+			throw error;
+		}
+
+		throw new FileNotAllowedError();
+	}
+}

--- a/app/src/application-services/images/helpers/form-data-parser.test.ts
+++ b/app/src/application-services/images/helpers/form-data-parser.test.ts
@@ -22,11 +22,13 @@ const mockMakePath = vi.mocked(makePath);
 const mockMakeContentType = vi.mocked(makeContentType);
 const mockMakeFileSize = vi.mocked(makeFileSize);
 const mockFileToBuffer = vi.mocked(sharpImageProcessor.fileToBuffer);
+const mockGetMetadata = vi.mocked(sharpImageProcessor.getMetadata);
 const mockCreateThumbnail = vi.mocked(sharpImageProcessor.createThumbnail);
 
 describe("parseAddImageFormData", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockGetMetadata.mockResolvedValue({ format: "png" });
 	});
 
 	test("should parse form data and create image data", async () => {
@@ -97,6 +99,7 @@ describe("parseAddImageFormData", () => {
 		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
 		mockMakeFileSize.mockReturnValue(1024 as FileSize);
 		mockFileToBuffer.mockResolvedValue(mockOriginalBuffer);
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockResolvedValue(mockThumbnailBuffer);
 
 		const result = await parseAddImageFormData(formData, userId);
@@ -113,6 +116,61 @@ describe("parseAddImageFormData", () => {
 			originalBuffer: mockOriginalBuffer,
 			thumbnailBuffer: mockThumbnailBuffer,
 		});
+	});
+
+	test("should accept JPEG image when browser does not provide content type", async () => {
+		const formData = new FormData();
+		const userId = makeUserId("test-user-id");
+		const mockFile = {
+			name: "photo.jpg",
+			type: "",
+			size: 1024,
+		} as File;
+		const mockOriginalBuffer = Buffer.from("jpeg-original-data");
+		const mockThumbnailBuffer = Buffer.from("jpeg-thumbnail-data");
+
+		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockMakePath.mockReturnValue("photo.jpg" as Path);
+		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
+		mockMakeFileSize.mockReturnValue(1024 as FileSize);
+		mockFileToBuffer.mockResolvedValue(mockOriginalBuffer);
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
+		mockCreateThumbnail.mockResolvedValue(mockThumbnailBuffer);
+
+		const result = await parseAddImageFormData(formData, userId);
+
+		expect(mockMakeContentType).toHaveBeenCalledWith("image/jpeg");
+		expect(mockCreateThumbnail).toHaveBeenCalledWith(
+			mockOriginalBuffer,
+			192,
+			192,
+		);
+		expect(result.contentType).toBe("image/jpeg");
+	});
+
+	test("should accept JPEG image when browser sends generic content type", async () => {
+		const formData = new FormData();
+		const userId = makeUserId("test-user-id");
+		const mockFile = {
+			name: "photo.jpg",
+			type: "application/octet-stream",
+			size: 1024,
+		} as File;
+		const mockOriginalBuffer = Buffer.from("octet-original-data");
+		const mockThumbnailBuffer = Buffer.from("octet-thumbnail-data");
+
+		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockMakePath.mockReturnValue("photo.jpg" as Path);
+		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
+		mockMakeFileSize.mockReturnValue(1024 as FileSize);
+		mockFileToBuffer.mockResolvedValue(mockOriginalBuffer);
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
+		mockCreateThumbnail.mockResolvedValue(mockThumbnailBuffer);
+
+		const result = await parseAddImageFormData(formData, userId);
+
+		expect(mockMakeContentType).toHaveBeenCalledWith("image/jpeg");
+		expect(result.contentType).toBe("image/jpeg");
 	});
 
 	test("should handle image with Japanese filename", async () => {
@@ -227,6 +285,7 @@ describe("parseAddImageFormData", () => {
 		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
 		mockMakeFileSize.mockReturnValue(1024 as FileSize);
 		mockFileToBuffer.mockResolvedValue(mockOriginalBuffer);
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockResolvedValue(mockThumbnailBuffer);
 
 		const result = await parseAddImageFormData(formData, userId);
@@ -234,7 +293,7 @@ describe("parseAddImageFormData", () => {
 		expect(result.userId).toBe("different-user-789");
 	});
 
-	test("should reject unsupported image content type before reading file", async () => {
+	test("should reject unsupported image format after reading metadata", async () => {
 		const formData = new FormData();
 		const userId = makeUserId("test-user-id");
 		const mockFile = {
@@ -244,11 +303,53 @@ describe("parseAddImageFormData", () => {
 		} as File;
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockFileToBuffer.mockResolvedValue(Buffer.from("avif-image-data"));
+		mockGetMetadata.mockResolvedValue({ format: "avif" });
 
 		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
 			FileNotAllowedError,
 		);
-		expect(mockFileToBuffer).not.toHaveBeenCalled();
+		expect(mockFileToBuffer).toHaveBeenCalledWith(mockFile);
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject image when metadata format is missing", async () => {
+		const formData = new FormData();
+		const userId = makeUserId("test-user-id");
+		const mockFile = {
+			name: "photo.jpg",
+			type: "",
+			size: 1024,
+		} as File;
+
+		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockFileToBuffer.mockResolvedValue(Buffer.from("image-data"));
+		mockGetMetadata.mockResolvedValue({});
+
+		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject images sharp cannot read metadata from", async () => {
+		const formData = new FormData();
+		const userId = makeUserId("test-user-id");
+		const mockFile = {
+			name: "photo.jpg",
+			type: "image/jpeg",
+			size: 1024,
+		} as File;
+
+		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockFileToBuffer.mockResolvedValue(Buffer.from("not-an-image"));
+		mockGetMetadata.mockRejectedValue(
+			new Error("Input buffer has corrupt header"),
+		);
+
+		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
 		expect(mockCreateThumbnail).not.toHaveBeenCalled();
 	});
 
@@ -266,6 +367,7 @@ describe("parseAddImageFormData", () => {
 		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
 		mockMakeFileSize.mockReturnValue(1024 as FileSize);
 		mockFileToBuffer.mockResolvedValue(Buffer.from("not-an-image"));
+		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockRejectedValue(
 			new Error("Input buffer has corrupt header"),
 		);

--- a/app/src/application-services/images/helpers/form-data-parser.ts
+++ b/app/src/application-services/images/helpers/form-data-parser.ts
@@ -9,6 +9,7 @@
  */
 
 import type { UserId } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
+import { parseSupportedImageFile } from "@/application-services/common/image-upload-parser";
 import { getFormDataFile } from "@/common/utils/form-data-utils";
 import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
 import {
@@ -17,19 +18,6 @@ import {
 	makePath,
 } from "@s-hirano-ist/s-core/images/entities/image-entity";
 import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
-
-const SUPPORTED_IMAGE_TYPES = new Set([
-	"image/jpeg",
-	"image/png",
-	"image/gif",
-	"image/webp",
-]);
-
-function assertSupportedImageType(contentType: string): void {
-	if (!SUPPORTED_IMAGE_TYPES.has(contentType)) {
-		throw new FileNotAllowedError();
-	}
-}
 
 async function createThumbnailOrThrowInvalidFile(
 	buffer: Buffer,
@@ -56,11 +44,11 @@ export const parseAddImageFormData = async (
 	userId: UserId,
 ) => {
 	const file = getFormDataFile(formData, "file");
-	assertSupportedImageType(file.type);
+	const { contentType: detectedContentType, originalBuffer } =
+		await parseSupportedImageFile(file);
 	const path = makePath(file.name, true);
-	const contentType = makeContentType(file.type);
+	const contentType = makeContentType(detectedContentType);
 	const fileSize = makeFileSize(file.size);
-	const originalBuffer = await sharpImageProcessor.fileToBuffer(file);
 	const thumbnailBuffer =
 		await createThumbnailOrThrowInvalidFile(originalBuffer);
 


### PR DESCRIPTION
## Summary
- Detect uploaded image format from sharp metadata instead of trusting browser-provided `File.type`.
- Share the supported image parsing logic between images and books dumper uploads.
- Keep support limited to existing JPEG, PNG, GIF, and WebP formats while accepting empty or generic browser MIME values when the image body is valid.

## Root Cause
The dumper rejected some valid images because the upload parser checked `File.type` before reading the actual image. Browser/OS-provided MIME values can be empty or generic even when the file is a valid JPEG.

## Validation
- `pnpm test app/src/application-services/images/helpers/form-data-parser.test.ts app/src/application-services/books/helpers/form-data-parser.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `pnpm deps:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 画像ファイル検証ロジックを改善しました。ブラウザが提供するファイル形式情報に依存せず、メタデータから正確に検出するよう変更されました。

* **Tests**
  * メタデータベースの画像フォーマット検証に対応したテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->