### PR TITLE
[codex] harden dumper image upload parsing

### DIFF
--- a/app/src/application-services/books/helpers/form-data-parser.test.ts
+++ b/app/src/application-services/books/helpers/form-data-parser.test.ts
@@ -79,6 +79,8 @@ const mockFileToBuffer = vi.mocked(sharpImageProcessor.fileToBuffer);
 const mockGetMetadata = vi.mocked(sharpImageProcessor.getMetadata);
 const mockCreateThumbnail = vi.mocked(sharpImageProcessor.createThumbnail);
 
+const JPEG_BUFFER = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+
 const buildMockFile = (
 	name = "cover.jpg",
 	type = "image/jpeg",
@@ -96,7 +98,7 @@ describe("parseAddBooksFormData", () => {
 		mockMakePath.mockImplementation((v) => v as Path);
 		mockMakeContentType.mockImplementation((v) => v as ContentType);
 		mockMakeFileSize.mockImplementation((v) => v as FileSize);
-		mockFileToBuffer.mockResolvedValue(Buffer.from([1, 2, 3]));
+		mockFileToBuffer.mockResolvedValue(JPEG_BUFFER);
 		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockResolvedValue(Buffer.from([4, 5, 6]));
 	});
@@ -295,7 +297,7 @@ describe("parseAddBooksFormData", () => {
 		expect(result.contentType).toBe("image/jpeg");
 	});
 
-	test("should reject unsupported cover image format after reading metadata", async () => {
+	test("should reject unsupported cover image signature before reading metadata", async () => {
 		const formData = new FormData();
 		const userId = "test-user-id" as UserId;
 
@@ -307,12 +309,32 @@ describe("parseAddBooksFormData", () => {
 		mockGetFormDataFile.mockReturnValueOnce(
 			buildMockFile("cover.avif", "image/avif"),
 		);
+		mockFileToBuffer.mockResolvedValue(Buffer.from("ftypavif"));
 		mockGetMetadata.mockResolvedValue({ format: "avif" });
 
 		await expect(parseAddBooksFormData(formData, userId)).rejects.toThrow(
 			FileNotAllowedError,
 		);
 		expect(mockFileToBuffer).toHaveBeenCalled();
+		expect(mockGetMetadata).not.toHaveBeenCalled();
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject cover image when magic bytes and sharp metadata do not match", async () => {
+		const formData = new FormData();
+		const userId = "test-user-id" as UserId;
+
+		mockGetFormDataString
+			.mockReturnValueOnce("9784123456789")
+			.mockReturnValueOnce("Clean Code")
+			.mockReturnValueOnce("5")
+			.mockReturnValueOnce("programming");
+		mockGetFormDataFile.mockReturnValueOnce(buildMockFile("cover.jpg", ""));
+		mockGetMetadata.mockResolvedValue({ format: "png" });
+
+		await expect(parseAddBooksFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
 		expect(mockCreateThumbnail).not.toHaveBeenCalled();
 	});
 

--- a/app/src/application-services/books/helpers/form-data-parser.ts
+++ b/app/src/application-services/books/helpers/form-data-parser.ts
@@ -10,7 +10,6 @@ import {
 	getFormDataFile,
 	getFormDataString,
 } from "@/common/utils/form-data-utils";
-import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
 import {
 	makeBookTitle,
 	makeISBN,
@@ -22,17 +21,6 @@ import {
 	makeFileSize,
 	makePath,
 } from "@s-hirano-ist/s-core/shared-kernel/entities/file-entity";
-import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
-
-async function createThumbnailOrThrowInvalidFile(
-	buffer: Buffer,
-): Promise<Buffer> {
-	try {
-		return await sharpImageProcessor.createThumbnail(buffer, 192, 192);
-	} catch {
-		throw new FileNotAllowedError();
-	}
-}
 
 /**
  * Parses book creation form data into domain value objects.
@@ -56,13 +44,14 @@ export const parseAddBooksFormData = async (
 		.map((t) => t.trim())
 		.filter((t) => t.length > 0);
 
-	const { contentType: detectedContentType, originalBuffer } =
-		await parseSupportedImageFile(file);
+	const {
+		contentType: detectedContentType,
+		originalBuffer,
+		thumbnailBuffer,
+	} = await parseSupportedImageFile(file);
 	const path = makePath(file.name, true);
 	const contentType = makeContentType(detectedContentType);
 	const fileSize = makeFileSize(file.size);
-	const thumbnailBuffer =
-		await createThumbnailOrThrowInvalidFile(originalBuffer);
 
 	return {
 		isbn: makeISBN(isbnInput),

--- a/app/src/application-services/common/image-upload-parser.test.ts
+++ b/app/src/application-services/common/image-upload-parser.test.ts
@@ -1,0 +1,54 @@
+import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
+import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
+import sharp from "sharp";
+import { describe, expect, test } from "vitest";
+import { parseSupportedImageFile } from "./image-upload-parser";
+
+describe("parseSupportedImageFile", () => {
+	test("should parse a JPEG file with no browser-provided content type", async () => {
+		const jpegBuffer = await sharp({
+			create: {
+				width: 10,
+				height: 10,
+				channels: 3,
+				background: { r: 255, g: 255, b: 255 },
+			},
+		})
+			.jpeg()
+			.toBuffer();
+		const file = new File([jpegBuffer], "generated.jpg", { type: "" });
+
+		const result = await parseSupportedImageFile(file);
+
+		expect(result.contentType).toBe("image/jpeg");
+		expect(result.originalBuffer).toEqual(jpegBuffer);
+		expect(result.thumbnailBuffer.length).toBeGreaterThan(0);
+	});
+
+	test("should reject an unsupported signature before thumbnail creation", async () => {
+		const file = new File([Buffer.from("ftypavif")], "image.avif", {
+			type: "image/avif",
+		});
+
+		await expect(parseSupportedImageFile(file)).rejects.toThrow(
+			FileNotAllowedError,
+		);
+	});
+
+	test("should use the tolerant sharp processor options for thumbnails", async () => {
+		const jpegBuffer = await sharp({
+			create: {
+				width: 10,
+				height: 10,
+				channels: 3,
+				background: { r: 0, g: 0, b: 0 },
+			},
+		})
+			.jpeg()
+			.toBuffer();
+
+		await expect(
+			sharpImageProcessor.createThumbnail(jpegBuffer),
+		).resolves.toBeInstanceOf(Buffer);
+	});
+});

--- a/app/src/application-services/common/image-upload-parser.ts
+++ b/app/src/application-services/common/image-upload-parser.ts
@@ -1,5 +1,5 @@
+import { UploadFileNotAllowedError } from "@/common/error/upload-file-not-allowed-error";
 import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
-import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
 
 const SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE = new Map<string, string>([
 	["jpeg", "image/jpeg"],
@@ -8,15 +8,102 @@ const SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE = new Map<string, string>([
 	["webp", "image/webp"],
 ]);
 
-function toSupportedImageContentType(format: string | undefined): string {
+type ImageSignatureMatcher = Readonly<{
+	contentType: string;
+	matches: (buffer: Buffer) => boolean;
+}>;
+
+function startsWithBytes(buffer: Buffer, bytes: readonly number[]): boolean {
+	return (
+		buffer.length >= bytes.length && bytes.every((b, i) => buffer[i] === b)
+	);
+}
+
+function startsWithAscii(buffer: Buffer, value: string): boolean {
+	return buffer.subarray(0, value.length).equals(Buffer.from(value, "ascii"));
+}
+
+const IMAGE_SIGNATURE_MATCHERS: readonly ImageSignatureMatcher[] = [
+	{
+		contentType: "image/jpeg",
+		matches: (buffer) => startsWithBytes(buffer, [0xff, 0xd8, 0xff]),
+	},
+	{
+		contentType: "image/png",
+		matches: (buffer) =>
+			startsWithBytes(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+	},
+	{
+		contentType: "image/gif",
+		matches: (buffer) =>
+			startsWithAscii(buffer, "GIF87a") || startsWithAscii(buffer, "GIF89a"),
+	},
+	{
+		contentType: "image/webp",
+		matches: (buffer) =>
+			buffer.length >= 12 &&
+			startsWithAscii(buffer, "RIFF") &&
+			buffer.subarray(8, 12).equals(Buffer.from("WEBP", "ascii")),
+	},
+];
+
+function createUploadFileNotAllowedError(
+	file: File,
+	reason: ConstructorParameters<typeof UploadFileNotAllowedError>[0]["reason"],
+	options?: Readonly<{
+		detectedContentType?: string;
+		sharpFormat?: string;
+		cause?: unknown;
+	}>,
+): UploadFileNotAllowedError {
+	const causeMessage =
+		options?.cause instanceof Error ? options.cause.message : undefined;
+
+	return new UploadFileNotAllowedError({
+		reason,
+		fileName: file.name,
+		fileSize: file.size,
+		declaredContentType: file.type,
+		detectedContentType: options?.detectedContentType,
+		sharpFormat: options?.sharpFormat,
+		causeMessage,
+	});
+}
+
+function detectContentTypeFromMagicBytes(buffer: Buffer): string | undefined {
+	if (buffer.length === 0) {
+		return undefined;
+	}
+
+	return IMAGE_SIGNATURE_MATCHERS.find((matcher) => matcher.matches(buffer))
+		?.contentType;
+}
+
+function toSupportedImageContentType(
+	file: File,
+	format: string | undefined,
+	detectedContentType: string,
+): string {
 	if (format === undefined) {
-		throw new FileNotAllowedError();
+		throw createUploadFileNotAllowedError(file, "metadata-format-missing", {
+			detectedContentType,
+		});
 	}
 
 	const contentType = SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE.get(format);
 
 	if (contentType === undefined) {
-		throw new FileNotAllowedError();
+		throw createUploadFileNotAllowedError(file, "metadata-format-unsupported", {
+			detectedContentType,
+			sharpFormat: format,
+		});
+	}
+
+	if (contentType !== detectedContentType) {
+		throw createUploadFileNotAllowedError(file, "detected-format-mismatch", {
+			detectedContentType,
+			sharpFormat: format,
+		});
 	}
 
 	return contentType;
@@ -25,19 +112,49 @@ function toSupportedImageContentType(format: string | undefined): string {
 export async function parseSupportedImageFile(file: File): Promise<{
 	contentType: string;
 	originalBuffer: Buffer;
+	thumbnailBuffer: Buffer;
 }> {
 	const originalBuffer = await sharpImageProcessor.fileToBuffer(file);
 
+	if (originalBuffer.length === 0) {
+		throw createUploadFileNotAllowedError(file, "empty-buffer");
+	}
+
+	const detectedContentType = detectContentTypeFromMagicBytes(originalBuffer);
+	if (detectedContentType === undefined) {
+		throw createUploadFileNotAllowedError(file, "unsupported-signature");
+	}
+
+	let sharpFormat: string | undefined;
 	try {
 		const metadata = await sharpImageProcessor.getMetadata(originalBuffer);
-		const contentType = toSupportedImageContentType(metadata.format);
-
-		return { contentType, originalBuffer };
+		sharpFormat = metadata.format;
 	} catch (error) {
-		if (error instanceof FileNotAllowedError) {
-			throw error;
-		}
+		throw createUploadFileNotAllowedError(file, "metadata-read-failed", {
+			detectedContentType,
+			cause: error,
+		});
+	}
 
-		throw new FileNotAllowedError();
+	const contentType = toSupportedImageContentType(
+		file,
+		sharpFormat,
+		detectedContentType,
+	);
+
+	try {
+		const thumbnailBuffer = await sharpImageProcessor.createThumbnail(
+			originalBuffer,
+			192,
+			192,
+		);
+
+		return { contentType, originalBuffer, thumbnailBuffer };
+	} catch (error) {
+		throw createUploadFileNotAllowedError(file, "thumbnail-creation-failed", {
+			detectedContentType,
+			sharpFormat,
+			cause: error,
+		});
 	}
 }

--- a/app/src/application-services/images/helpers/form-data-parser.test.ts
+++ b/app/src/application-services/images/helpers/form-data-parser.test.ts
@@ -25,6 +25,12 @@ const mockFileToBuffer = vi.mocked(sharpImageProcessor.fileToBuffer);
 const mockGetMetadata = vi.mocked(sharpImageProcessor.getMetadata);
 const mockCreateThumbnail = vi.mocked(sharpImageProcessor.createThumbnail);
 
+const JPEG_BUFFER = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+const PNG_BUFFER = Buffer.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const UNKNOWN_BUFFER = Buffer.from("not-an-image");
+
 describe("parseAddImageFormData", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -41,7 +47,7 @@ describe("parseAddImageFormData", () => {
 			size: 1024,
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("original-image-data");
+		const mockOriginalBuffer = PNG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("thumbnail-image-data");
 
 		// Mock form data extraction
@@ -88,7 +94,7 @@ describe("parseAddImageFormData", () => {
 			size: 1024,
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("jpeg-original-data");
+		const mockOriginalBuffer = JPEG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("jpeg-thumbnail-data");
 
 		// Mock form data extraction
@@ -126,7 +132,7 @@ describe("parseAddImageFormData", () => {
 			type: "",
 			size: 1024,
 		} as File;
-		const mockOriginalBuffer = Buffer.from("jpeg-original-data");
+		const mockOriginalBuffer = JPEG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("jpeg-thumbnail-data");
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
@@ -156,7 +162,7 @@ describe("parseAddImageFormData", () => {
 			type: "application/octet-stream",
 			size: 1024,
 		} as File;
-		const mockOriginalBuffer = Buffer.from("octet-original-data");
+		const mockOriginalBuffer = JPEG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("octet-thumbnail-data");
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
@@ -183,7 +189,7 @@ describe("parseAddImageFormData", () => {
 			size: 1536,
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("japanese-original-data");
+		const mockOriginalBuffer = PNG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("japanese-thumbnail-data");
 
 		// Mock form data extraction
@@ -213,7 +219,7 @@ describe("parseAddImageFormData", () => {
 			size: 5242880, // 5MB
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("large-original-data");
+		const mockOriginalBuffer = PNG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("large-thumbnail-data");
 
 		// Mock form data extraction
@@ -242,7 +248,7 @@ describe("parseAddImageFormData", () => {
 			size: 1024,
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("special-original-data");
+		const mockOriginalBuffer = PNG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("special-thumbnail-data");
 
 		// Mock form data extraction
@@ -274,7 +280,7 @@ describe("parseAddImageFormData", () => {
 			size: 1024,
 		} as File;
 
-		const mockOriginalBuffer = Buffer.from("user-original-data");
+		const mockOriginalBuffer = JPEG_BUFFER;
 		const mockThumbnailBuffer = Buffer.from("user-thumbnail-data");
 
 		// Mock form data extraction
@@ -293,7 +299,7 @@ describe("parseAddImageFormData", () => {
 		expect(result.userId).toBe("different-user-789");
 	});
 
-	test("should reject unsupported image format after reading metadata", async () => {
+	test("should reject unsupported image signature before reading metadata", async () => {
 		const formData = new FormData();
 		const userId = makeUserId("test-user-id");
 		const mockFile = {
@@ -303,13 +309,33 @@ describe("parseAddImageFormData", () => {
 		} as File;
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
-		mockFileToBuffer.mockResolvedValue(Buffer.from("avif-image-data"));
+		mockFileToBuffer.mockResolvedValue(Buffer.from("ftypavif"));
 		mockGetMetadata.mockResolvedValue({ format: "avif" });
 
 		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
 			FileNotAllowedError,
 		);
 		expect(mockFileToBuffer).toHaveBeenCalledWith(mockFile);
+		expect(mockGetMetadata).not.toHaveBeenCalled();
+		expect(mockCreateThumbnail).not.toHaveBeenCalled();
+	});
+
+	test("should reject when magic bytes and sharp metadata do not match", async () => {
+		const formData = new FormData();
+		const userId = makeUserId("test-user-id");
+		const mockFile = {
+			name: "photo.jpg",
+			type: "",
+			size: 1024,
+		} as File;
+
+		mockGetFormDataFile.mockReturnValue(mockFile);
+		mockFileToBuffer.mockResolvedValue(JPEG_BUFFER);
+		mockGetMetadata.mockResolvedValue({ format: "png" });
+
+		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
+			FileNotAllowedError,
+		);
 		expect(mockCreateThumbnail).not.toHaveBeenCalled();
 	});
 
@@ -323,7 +349,7 @@ describe("parseAddImageFormData", () => {
 		} as File;
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
-		mockFileToBuffer.mockResolvedValue(Buffer.from("image-data"));
+		mockFileToBuffer.mockResolvedValue(JPEG_BUFFER);
 		mockGetMetadata.mockResolvedValue({});
 
 		await expect(parseAddImageFormData(formData, userId)).rejects.toThrow(
@@ -342,7 +368,7 @@ describe("parseAddImageFormData", () => {
 		} as File;
 
 		mockGetFormDataFile.mockReturnValue(mockFile);
-		mockFileToBuffer.mockResolvedValue(Buffer.from("not-an-image"));
+		mockFileToBuffer.mockResolvedValue(JPEG_BUFFER);
 		mockGetMetadata.mockRejectedValue(
 			new Error("Input buffer has corrupt header"),
 		);
@@ -366,7 +392,7 @@ describe("parseAddImageFormData", () => {
 		mockMakePath.mockReturnValue("photo.jpeg" as Path);
 		mockMakeContentType.mockReturnValue("image/jpeg" as ContentType);
 		mockMakeFileSize.mockReturnValue(1024 as FileSize);
-		mockFileToBuffer.mockResolvedValue(Buffer.from("not-an-image"));
+		mockFileToBuffer.mockResolvedValue(JPEG_BUFFER);
 		mockGetMetadata.mockResolvedValue({ format: "jpeg" });
 		mockCreateThumbnail.mockRejectedValue(
 			new Error("Input buffer has corrupt header"),

--- a/app/src/application-services/images/helpers/form-data-parser.ts
+++ b/app/src/application-services/images/helpers/form-data-parser.ts
@@ -11,23 +11,11 @@
 import type { UserId } from "@s-hirano-ist/s-core/shared-kernel/entities/common-entity";
 import { parseSupportedImageFile } from "@/application-services/common/image-upload-parser";
 import { getFormDataFile } from "@/common/utils/form-data-utils";
-import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
 import {
 	makeContentType,
 	makeFileSize,
 	makePath,
 } from "@s-hirano-ist/s-core/images/entities/image-entity";
-import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
-
-async function createThumbnailOrThrowInvalidFile(
-	buffer: Buffer,
-): Promise<Buffer> {
-	try {
-		return await sharpImageProcessor.createThumbnail(buffer, 192, 192);
-	} catch {
-		throw new FileNotAllowedError();
-	}
-}
 
 /**
  * Parses image upload form data into domain value objects.
@@ -44,13 +32,14 @@ export const parseAddImageFormData = async (
 	userId: UserId,
 ) => {
 	const file = getFormDataFile(formData, "file");
-	const { contentType: detectedContentType, originalBuffer } =
-		await parseSupportedImageFile(file);
+	const {
+		contentType: detectedContentType,
+		originalBuffer,
+		thumbnailBuffer,
+	} = await parseSupportedImageFile(file);
 	const path = makePath(file.name, true);
 	const contentType = makeContentType(detectedContentType);
 	const fileSize = makeFileSize(file.size);
-	const thumbnailBuffer =
-		await createThumbnailOrThrowInvalidFile(originalBuffer);
 
 	return {
 		userId,

--- a/app/src/common/error/error-wrapper.test.ts
+++ b/app/src/common/error/error-wrapper.test.ts
@@ -1,4 +1,5 @@
 import type { ZodError } from "zod";
+import { UploadFileNotAllowedError } from "@/common/error/upload-file-not-allowed-error";
 import { eventDispatcher } from "@/infrastructures/events/event-dispatcher";
 import { UnexpectedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
 import { Prisma } from "@s-hirano-ist/s-database";
@@ -93,6 +94,42 @@ describe("wrapServerSideErrorForClient", () => {
 		expect(result).toEqual({
 			success: false,
 			message: error.message,
+		});
+	});
+
+	test("should log upload file rejection diagnostics without changing client message", async () => {
+		const error = new UploadFileNotAllowedError({
+			reason: "metadata-read-failed",
+			fileName: "IMG_9521.jpg",
+			fileSize: 2_000_000,
+			declaredContentType: "",
+			detectedContentType: "image/jpeg",
+			causeMessage: "Input buffer has corrupt header",
+		});
+
+		const result = await wrapServerSideErrorForClient(error);
+
+		expect(eventDispatcher.dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "system.warning",
+				payload: expect.objectContaining({
+					message: "invalidFileFormat",
+					status: 500,
+					extraData: {
+						reason: "metadata-read-failed",
+						fileName: "IMG_9521.jpg",
+						fileSize: 2_000_000,
+						declaredContentType: "",
+						detectedContentType: "image/jpeg",
+						causeMessage: "Input buffer has corrupt header",
+					},
+					shouldNotify: true,
+				}),
+			}),
+		);
+		expect(result).toEqual({
+			success: false,
+			message: "invalidFileFormat",
 		});
 	});
 

--- a/app/src/common/error/error-wrapper.ts
+++ b/app/src/common/error/error-wrapper.ts
@@ -26,6 +26,7 @@ import { S3Error, StorageOperationError } from "@s-hirano-ist/s-storage";
 import { APIError } from "better-auth/api";
 import { ZodError } from "zod";
 import { OperationPhaseError } from "./operation-phase-error";
+import { getUploadFileNotAllowedDiagnostics } from "./upload-file-not-allowed-error";
 
 /**
  * Converts FormData to a plain record for error responses.
@@ -110,11 +111,13 @@ async function handleDomainWarningError(
 		error instanceof InvalidFormatError ||
 		error instanceof FileNotAllowedError
 	) {
+		const extraData = getUploadFileNotAllowedDiagnostics(error);
 		await eventDispatcher.dispatch(
 			new SystemWarningEvent({
 				message: error.message,
 				status: 500,
 				caller: "wrapServerSideError",
+				extraData,
 				shouldNotify: true,
 			}),
 		);

--- a/app/src/common/error/upload-file-not-allowed-error.ts
+++ b/app/src/common/error/upload-file-not-allowed-error.ts
@@ -1,0 +1,40 @@
+import { FileNotAllowedError } from "@s-hirano-ist/s-core/shared-kernel/errors/error-classes";
+
+export type UploadFileNotAllowedReason =
+	| "empty-buffer"
+	| "unsupported-signature"
+	| "metadata-read-failed"
+	| "metadata-format-missing"
+	| "metadata-format-unsupported"
+	| "detected-format-mismatch"
+	| "thumbnail-creation-failed";
+
+export type UploadFileNotAllowedDiagnostics = Readonly<{
+	reason: UploadFileNotAllowedReason;
+	fileName: string;
+	fileSize: number;
+	declaredContentType: string;
+	detectedContentType?: string;
+	sharpFormat?: string;
+	causeMessage?: string;
+}>;
+
+export class UploadFileNotAllowedError extends FileNotAllowedError {
+	readonly diagnostics: UploadFileNotAllowedDiagnostics;
+
+	constructor(diagnostics: UploadFileNotAllowedDiagnostics) {
+		super();
+		this.name = "UploadFileNotAllowedError";
+		this.diagnostics = diagnostics;
+	}
+}
+
+export function getUploadFileNotAllowedDiagnostics(
+	error: unknown,
+): UploadFileNotAllowedDiagnostics | undefined {
+	if (error instanceof UploadFileNotAllowedError) {
+		return error.diagnostics;
+	}
+
+	return undefined;
+}

--- a/app/src/infrastructures/events/handlers/system-event-handler.test.ts
+++ b/app/src/infrastructures/events/handlers/system-event-handler.test.ts
@@ -69,6 +69,30 @@ describe("SystemEventHandler", () => {
 		);
 	});
 
+	test("should include warning extra data in log context", async () => {
+		const event = createEvent("system.warning", {
+			message: "Upload file rejected",
+			status: 500,
+			shouldNotify: true,
+			extraData: { reason: "metadata-read-failed" },
+		});
+
+		await handler.handle(event);
+
+		expect(serverLogger.warn).toHaveBeenCalledWith(
+			"Upload file rejected",
+			{
+				caller: "testCaller",
+				status: 500,
+				userId: "user-123",
+				additionalContext: {
+					extraData: { reason: "metadata-read-failed" },
+				},
+			},
+			{ notify: true },
+		);
+	});
+
 	test("should pass notify option when shouldNotify is true for error", async () => {
 		const event = createEvent("system.error", {
 			message: "Error with notify",

--- a/app/src/infrastructures/events/handlers/system-event-handler.ts
+++ b/app/src/infrastructures/events/handlers/system-event-handler.ts
@@ -13,6 +13,9 @@ export class SystemEventHandler implements DomainEventHandler {
 			caller: metadata.caller,
 			status: payload.status as LogContext["status"],
 			userId: metadata.userId,
+			...(eventType !== "system.warning" || payload.extraData === undefined
+				? {}
+				: { additionalContext: { extraData: payload.extraData } }),
 		};
 
 		const notifyOptions = payload.shouldNotify

--- a/app/src/infrastructures/images/services/sharp-image-processor.ts
+++ b/app/src/infrastructures/images/services/sharp-image-processor.ts
@@ -42,12 +42,17 @@ async function createThumbnail(
 	height: number = THUMBNAIL_HEIGHT,
 ): Promise<Buffer> {
 	const sharp = await loadSharp();
-	return await sharp(buffer).resize(width, height).toBuffer();
+	return await sharp(buffer, { autoOrient: true, failOn: "none" })
+		.resize(width, height)
+		.toBuffer();
 }
 
 async function getMetadata(buffer: Buffer): Promise<ImageMetadata> {
 	const sharp = await loadSharp();
-	const metadata = await sharp(buffer).metadata();
+	const metadata = await sharp(buffer, {
+		autoOrient: true,
+		failOn: "none",
+	}).metadata();
 	return {
 		width: metadata.width,
 		height: metadata.height,


### PR DESCRIPTION
## Summary
- Harden dumper image upload parsing with magic-byte detection plus sharp metadata validation.
- Generate thumbnails in the shared upload parser and use tolerant sharp options (`failOn: "none"`, `autoOrient: true`).
- Add upload-specific diagnostics for rejected files while preserving the existing user-facing `invalidFileFormat` message.

## Root Cause
The previous fix removed reliance on browser-provided `File.type`, but failures were still collapsed into the same client message without enough server-side context. Production-only sharp/libvips differences or thumbnail failures could not be distinguished from unsupported formats.

## Impact
Valid JPEG/PNG/GIF/WebP uploads are detected from file signatures and verified by sharp before storage. If a file is rejected again, Vercel/Pushover warning logs should include the rejection reason, detected content type, sharp format, file metadata, and cause message.

## Validation
- `pnpm test app/src/application-services/common/image-upload-parser.test.ts app/src/application-services/images/helpers/form-data-parser.test.ts app/src/application-services/books/helpers/form-data-parser.test.ts app/src/common/error/error-wrapper.test.ts app/src/infrastructures/events/handlers/system-event-handler.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `pnpm deps:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 画像アップロード検証を強化し、より厳密な形式チェックを実装しました。

* **Tests**
  * 画像アップロード処理の検証テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->