### PR TITLE
[codex] include sharp native files in trace

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -3,6 +3,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 // import { env } from "./src/env.ts";
 // await import("./src/env.ts");
 import createNextIntlPlugin from "next-intl/plugin";
+import path from "node:path";
 
 // MEMO: その他のheadersについては下記参照
 // https://nextjs.org/docs/pages/api-reference/next-config-js/headers
@@ -16,6 +17,17 @@ const nextConfig = {
 		"@s-hirano-ist/s-ui",
 	],
 	serverExternalPackages: ["sharp", "@prisma/client"],
+	outputFileTracingRoot: path.join(import.meta.dirname, ".."),
+	outputFileTracingIncludes: {
+		"/*": [
+			"node_modules/sharp/**/*",
+			"../node_modules/.pnpm/sharp@*/node_modules/sharp/**/*",
+			"../node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64/**/*",
+			"../node_modules/.pnpm/@img+sharp-linuxmusl-x64@*/node_modules/@img/sharp-linuxmusl-x64/**/*",
+			"../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64/**/*",
+			"../node_modules/.pnpm/@img+sharp-libvips-linuxmusl-x64@*/node_modules/@img/sharp-libvips-linuxmusl-x64/**/*",
+		],
+	},
 	typedRoutes: true,
 	reactCompiler: true,
 	experimental: {

--- a/app/src/application-services/common/image-upload-parser.test.ts
+++ b/app/src/application-services/common/image-upload-parser.test.ts
@@ -4,6 +4,12 @@ import sharp from "sharp";
 import { describe, expect, test } from "vitest";
 import { parseSupportedImageFile } from "./image-upload-parser";
 
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+	const arrayBuffer = new ArrayBuffer(buffer.byteLength);
+	new Uint8Array(arrayBuffer).set(buffer);
+	return arrayBuffer;
+}
+
 describe("parseSupportedImageFile", () => {
 	test("should parse a JPEG file with no browser-provided content type", async () => {
 		const jpegBuffer = await sharp({
@@ -16,7 +22,9 @@ describe("parseSupportedImageFile", () => {
 		})
 			.jpeg()
 			.toBuffer();
-		const file = new File([jpegBuffer], "generated.jpg", { type: "" });
+		const file = new File([toArrayBuffer(jpegBuffer)], "generated.jpg", {
+			type: "",
+		});
 
 		const result = await parseSupportedImageFile(file);
 
@@ -48,7 +56,7 @@ describe("parseSupportedImageFile", () => {
 			.toBuffer();
 
 		await expect(
-			sharpImageProcessor.createThumbnail(jpegBuffer),
+			sharpImageProcessor.createThumbnail(jpegBuffer, 192, 192),
 		).resolves.toBeInstanceOf(Buffer);
 	});
 });

--- a/app/src/application-services/common/image-upload-parser.ts
+++ b/app/src/application-services/common/image-upload-parser.ts
@@ -1,4 +1,7 @@
-import { UploadFileNotAllowedError } from "@/common/error/upload-file-not-allowed-error";
+import {
+	UploadFileNotAllowedError,
+	type UploadFileNotAllowedReason,
+} from "@/common/error/upload-file-not-allowed-error";
 import { sharpImageProcessor } from "@/infrastructures/images/services/sharp-image-processor";
 
 const SUPPORTED_IMAGE_FORMAT_TO_CONTENT_TYPE = new Map<string, string>([
@@ -49,7 +52,7 @@ const IMAGE_SIGNATURE_MATCHERS: readonly ImageSignatureMatcher[] = [
 
 function createUploadFileNotAllowedError(
 	file: File,
-	reason: ConstructorParameters<typeof UploadFileNotAllowedError>[0]["reason"],
+	reason: UploadFileNotAllowedReason,
 	options?: Readonly<{
 		detectedContentType?: string;
 		sharpFormat?: string;


### PR DESCRIPTION
## Summary
- Add explicit Next.js output file tracing includes for `sharp` and the Linux x64/musl `@img/sharp-*` native packages.
- Set `outputFileTracingRoot` to the monorepo root so the app can include pnpm store files outside the Next.js project directory.
- Clean up the image-upload parser test types so app typecheck stays green.

## Root Cause
Production logs show the uploaded JPEG is detected correctly, but `sharp` fails to load on Vercel because `libvips-cpp.so.8.18.3` is missing from the Linux runtime bundle. The upload failure is therefore a deployment artifact tracing issue, not an image format issue.

## Impact
The standalone server output should now include the Linux `sharp` native addon and libvips package needed by Vercel Functions, allowing JPEG metadata and thumbnail generation to run in production.

## Validation
- `pnpm format:check app/next.config.mjs app/src/application-services/common/image-upload-parser.ts app/src/application-services/common/image-upload-parser.test.ts`
- `pnpm lint app/next.config.mjs app/src/application-services/common/image-upload-parser.ts app/src/application-services/common/image-upload-parser.test.ts`
- `pnpm --filter s-private-app typecheck`
- `pnpm test app/src/application-services/common/image-upload-parser.test.ts app/src/application-services/images/helpers/form-data-parser.test.ts app/src/application-services/books/helpers/form-data-parser.test.ts`