### PR TITLE
[codex] install sharp linux libvips optional deps

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,10 @@
 		"yet-another-react-lightbox": "3.32.0",
 		"zod": "4.4.3"
 	},
+	"optionalDependencies": {
+		"@img/sharp-libvips-linux-x64": "1.3.0",
+		"@img/sharp-linux-x64": "0.35.1"
+	},
 	"browserslist": [
 		"last 2 Chrome versions",
 		"last 2 Firefox versions",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,13 @@ importers:
       zod:
         specifier: 4.4.3
         version: 4.4.3
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@img/sharp-linux-x64':
+        specifier: 0.35.1
+        version: 0.35.1
     devDependencies:
       '@tailwindcss/postcss':
         specifier: 4.3.1


### PR DESCRIPTION
## Summary
- Add Linux x64 `sharp` native packages as explicit app `optionalDependencies`.
- Update the pnpm lockfile importer so Vercel installs `@img/sharp-linux-x64` and `@img/sharp-libvips-linux-x64` as app-level optional dependencies.

## Root Cause
The latest production log proves the upload parser detects the JPEG correctly, but `sharp` fails at runtime because `libvips-cpp.so.8.18.3` is missing:

```text
Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file
```

The previous trace include made the error visible and tried to include native files in the standalone output, but Vercel still needs the Linux libvips package to be installed in the app dependency graph first. Making these packages explicit optional dependencies should ensure they exist during the Linux build and can be traced into the function bundle.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=true CI=true pnpm install`
- `pnpm format:check app/package.json pnpm-lock.yaml`
- `pnpm --filter s-private-app typecheck`
- `pnpm test app/src/application-services/common/image-upload-parser.test.ts app/src/application-services/images/helpers/form-data-parser.test.ts app/src/application-services/books/helpers/form-data-parser.test.ts`
- `pnpm deps:check` (passes with existing orphan warnings only)

## Notes
- `pnpm lint app/package.json` was not applicable because oxlint has no JSON target for that path.
- `gh auth status` reports an expired local GitHub CLI token, so this PR was created through the GitHub connector.