### PR TITLE
fix: include photon package in server bundle

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -17,7 +17,7 @@ const nextConfig = {
 		"@s-hirano-ist/s-search",
 		"@s-hirano-ist/s-ui",
 	],
-	serverExternalPackages: ["@prisma/client"],
+	serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon"],
 	outputFileTracingRoot: path.join(import.meta.dirname, ".."),
 	outputFileTracingIncludes: {
 		"/*": [


### PR DESCRIPTION
### Motivation
- Vercel server runtime failed to `require.resolve` the Photon WASM (`@silvia-odwyer/photon/photon_rs_bg.wasm`) when reading image metadata, causing deploy-time errors; the server package must be included in the server bundle so the traced WASM asset can be resolved at runtime.

### Description
- Add `@silvia-odwyer/photon` to `serverExternalPackages` in `app/next.config.mjs` so Vercel server functions include the Photon package alongside the already-traced WASM (`outputFileTracingIncludes`).

### Testing
- Ran `pnpm lint app/next.config.mjs` which succeeded.
- Ran `pnpm --filter s-private-app typecheck` which failed due to an existing `Uint8Array` → `BlobPart` type error in `app/src/application-services/common/image-upload-parser.test.ts`, unrelated to this config change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3672f67b2c83299465fc6be748d839)