### PR TITLE
Fix server image processing Photon import

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -17,13 +17,8 @@ const nextConfig = {
 		"@s-hirano-ist/s-search",
 		"@s-hirano-ist/s-ui",
 	],
-	serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon"],
+	serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon-node"],
 	outputFileTracingRoot: path.join(import.meta.dirname, ".."),
-	outputFileTracingIncludes: {
-		"/*": [
-			"../node_modules/.pnpm/@silvia-odwyer+photon@*/node_modules/@silvia-odwyer/photon/photon_rs_bg.wasm",
-		],
-	},
 	typedRoutes: true,
 	reactCompiler: true,
 	experimental: {

--- a/app/src/infrastructures/images/services/photon-image-processor.ts
+++ b/app/src/infrastructures/images/services/photon-image-processor.ts
@@ -16,7 +16,7 @@ import {
 	createWebpThumbnail,
 	fileToBytes,
 	readImageMetadata,
-} from "@s-hirano-ist/s-image-processing";
+} from "@s-hirano-ist/s-image-processing/node";
 
 const THUMBNAIL_WIDTH = 192;
 const THUMBNAIL_HEIGHT = 192;


### PR DESCRIPTION
### Motivation
- Prevent server-side rendering from attempting to `require` the browser/WebAssembly Photon ESM wrapper which caused a `SyntaxError: Unexpected token 'export'` during SSR for `/ja/images` by using the Node-specific entrypoint.
- Align Next.js externalization to the Node Photon package so the server runtime loads `@silvia-odwyer/photon-node` instead of the browser WASM package.

### Description
- Change import in `app/src/infrastructures/images/services/photon-image-processor.ts` to use the Node-specific entrypoint `@s-hirano-ist/s-image-processing/node` instead of the web entrypoint.
- Update `app/next.config.mjs` to externalize `@silvia-odwyer/photon-node` and remove the previous WebAssembly tracing include for the browser Photon package.
- Commit message: "Fix server image processing Photon import".

### Testing
- Ran `pnpm format app/src/infrastructures/images/services/photon-image-processor.ts app/next.config.mjs` which completed successfully.
- Ran `pnpm --filter @s-hirano-ist/s-image-processing typecheck` which succeeded.
- Ran `pnpm lint` which succeeded and `git diff --check` which reported no issues.
- Ran `pnpm --filter s-private-app typecheck` which failed due to an existing unrelated test fixture TypeScript error (`Uint8Array<ArrayBufferLike>` vs `BlobPart`) in `app/src/application-services/common/image-upload-parser.test.ts` and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3676e9c4c88329bb2d4e8db78b1683)