### PR TITLE
Use node variant of image-processing and adjust config/tests

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -17,13 +17,8 @@ const nextConfig = {
 		"@s-hirano-ist/s-search",
 		"@s-hirano-ist/s-ui",
 	],
-	serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon"],
+	serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon-node"],
 	outputFileTracingRoot: path.join(import.meta.dirname, ".."),
-	outputFileTracingIncludes: {
-		"/*": [
-			"../node_modules/.pnpm/@silvia-odwyer+photon@*/node_modules/@silvia-odwyer/photon/photon_rs_bg.wasm",
-		],
-	},
 	typedRoutes: true,
 	reactCompiler: true,
 	experimental: {

--- a/app/src/application-services/common/image-upload-parser.test.ts
+++ b/app/src/application-services/common/image-upload-parser.test.ts
@@ -15,8 +15,8 @@ const WEBP_BYTES = Buffer.from(
 	"base64",
 );
 
-function buildFile(bytes: Uint8Array, name: string, type = ""): File {
-	return new File([bytes], name, { type });
+function buildFile(bytes: Buffer, name: string, type = ""): File {
+	return new File([new Uint8Array(bytes)], name, { type });
 }
 
 function isWebp(bytes: Uint8Array): boolean {

--- a/app/src/infrastructures/images/services/photon-image-processor.ts
+++ b/app/src/infrastructures/images/services/photon-image-processor.ts
@@ -16,7 +16,7 @@ import {
 	createWebpThumbnail,
 	fileToBytes,
 	readImageMetadata,
-} from "@s-hirano-ist/s-image-processing";
+} from "@s-hirano-ist/s-image-processing/node";
 
 const THUMBNAIL_WIDTH = 192;
 const THUMBNAIL_HEIGHT = 192;


### PR DESCRIPTION
### Motivation
- Replace the browser/WASM-oriented photon package usage with a Node-targeted variant to avoid runtime/tracing issues with the Photon WASM build.
- Simplify Next.js output tracing configuration that was explicitly including Photon WASM artifacts.
- Fix test `File` construction to work with Node `Buffer` values when running tests under `vitest`.

### Description
- Change import in `photon-image-processor.ts` from `@s-hirano-ist/s-image-processing` to the Node entry `@s-hirano-ist/s-image-processing/node` and keep the same image-processing API usage for `createWebpThumbnail`, `fileToBytes`, and `readImageMetadata`.
- Update `next.config.mjs` to use `serverExternalPackages: ["@prisma/client", "@silvia-odwyer/photon-node"]` and remove the `outputFileTracingIncludes` entry that referenced the Photon WASM binary.
- Adjust the test helper `buildFile` in `image-upload-parser.test.ts` to accept a `Buffer` and create the `File` with `new Uint8Array(bytes)` to ensure compatibility in the test environment.

### Testing
- Ran the `vitest` unit test suite including `image-upload-parser.test.ts` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3676e9c4c88329bb2d4e8db78b1683)