### PR TITLE
Fix oxlint eslint plugin alias

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -58,7 +58,10 @@
 			"name": "react-hooks-js",
 			"specifier": "eslint-plugin-react-hooks"
 		},
-		"oxlint-plugin-eslint",
+		{
+			"name": "eslint-js",
+			"specifier": "oxlint-plugin-eslint"
+		},
 		"eslint-plugin-sonarjs",
 		{
 			"name": "unicorn-js",


### PR DESCRIPTION
### Motivation
- oxlint failed to parse the configuration because a JS plugin was referenced by the reserved name `eslint`, causing the lint job to error; an alias is required to avoid the name conflict while keeping existing rule references.

### Description
- Update `.oxlintrc.json` to replace the bare `"oxlint-plugin-eslint"` entry in `jsPlugins` with an aliased JS plugin object `{ "name": "eslint-js", "specifier": "oxlint-plugin-eslint" }`, allowing rules to be referenced as `eslint-js/...` without colliding with oxlint's native `eslint` plugin.

### Testing
- Executed `pnpm i --frozen-lockfile`, `SKIP_ENV_VALIDATION=true pnpm --filter s-private-app exec next typegen`, and `SKIP_ENV_VALIDATION=true pnpm lint`, and all commands completed successfully (lint failed with the config parse error before this fix and succeeded after the change); note there was a non-blocking engine warning about Node version during runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd30ef84c8329b785d31d4f1b185f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プラグイン設定の指定方法を更新し、別名を明示した形式に統一しました。
  * 設定の表記がわかりやすくなり、今後の管理や確認がしやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->