### PR TITLE
Add Renovate packageRule to group `pnpm.overrides` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,14 @@
 			automerge: true,
 		},
 		{
+			matchManagers: ["npm"],
+			matchDepTypes: ["pnpm.overrides"],
+			groupName: "pnpm overrides",
+			groupSlug: "pnpm-overrides",
+			minimumReleaseAge: "2 days",
+			automerge: false,
+		},
+		{
 			matchManagers: ["mise"],
 			groupName: "mise",
 			groupSlug: "mise",


### PR DESCRIPTION
### Motivation
- Ensure Renovate groups dependency updates for `pnpm.overrides` separately and applies controlled automation for those changes. 

### Description
- Added a new package rule to `.github/renovate.json5` that matches `pnpm.overrides` via `matchDepTypes` and groups them under `pnpm overrides` with slug `pnpm-overrides`.
- The rule sets `minimumReleaseAge` to `2 days` and disables `automerge` for these grouped updates.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487962ede08329a595d8406eff8316)