### PR TITLE
chore: update js-yaml to v5

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,8 +2,8 @@
 	"$schema": "https://unpkg.com/knip@5/schema.json",
 	"ignoreExportsUsedInFile": true,
 	"ignore": ["e2e/**/*"],
-	"ignoreDependencies": ["babel-plugin-react-compiler"],
-	"ignoreBinaries": ["dot", "serve", "only-allow"],
+	"ignoreDependencies": [],
+	"ignoreBinaries": [],
 	"workspaces": {
 		"app": {
 			"ignore": [
@@ -55,11 +55,7 @@
 			"project": ["**/*.ts"]
 		},
 		"packages/database": {
-			"ignoreDependencies": [
-				"@prisma/client",
-				"@prisma/client-runtime-utils",
-				"prisma-erd-generator"
-			]
+			"ignoreDependencies": ["@prisma/client-runtime-utils"]
 		}
 	}
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,11 +95,10 @@
 		"glob": "13.0.6",
 		"gray-matter": "4.0.3",
 		"iconv-lite": "0.7.2",
-		"js-yaml": "4.3.0",
+		"js-yaml": "5.2.1",
 		"turndown": "7.2.4"
 	},
 	"devDependencies": {
-		"@types/js-yaml": "4.0.9",
 		"@types/node": "24.13.2",
 		"@types/turndown": "5.0.6",
 		"tsx": "4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,15 +346,12 @@ importers:
         specifier: 0.7.2
         version: 0.7.2
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 5.2.1
+        version: 5.2.1
       turndown:
         specifier: 7.2.4
         version: 7.2.4
     devDependencies:
-      '@types/js-yaml':
-        specifier: 4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -4721,9 +4718,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -7045,6 +7039,10 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jscpd@5.0.11:
@@ -11471,7 +11469,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.8.4
+      semver: 7.8.5
       tar-fs: 3.1.2
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -12981,8 +12979,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -13672,15 +13668,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-jsx-walk@2.0.0: {}
-
-  acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -14899,8 +14891,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
@@ -15597,6 +15589,10 @@ snapshots:
       argparse: 2.0.1
 
   js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -17894,7 +17890,7 @@ snapshots:
   terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -18347,11 +18343,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.22.1
+      enhanced-resolve: 5.24.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
## Summary
- Updated `js-yaml` in `@s-hirano-ist/s-scripts` to v5.2.1.
- Removed the obsolete `@types/js-yaml` devDependency because js-yaml v5 ships types.
- Cleaned stale Knip ignore entries so `pnpm knip` passes after the dependency update.

## Checks
- `pnpm knip`
- `pnpm --filter @s-hirano-ist/s-scripts typecheck`
- `pnpm format:check`
- `git diff --check`

## Notes
- Commands emitted an engine warning because this environment uses Node v22.22.2 while the repo expects Node 24.18.0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487f02ed808329af423134b0131e3b)