### PR TITLE
[codex] Remove local MCP config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,0 @@
-[mcp_servers.next-devtools]
-command = "npx"
-args = ["-y", "next-devtools-mcp@latest"]
-
-[mcp_servers.storybook-mcp]
-url = "http://localhost:6006/mcp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-	"mcpServers": {
-		"next-devtools": {
-			"command": "npx",
-			"args": ["-y", "next-devtools-mcp@latest"]
-		}
-	}
-}


### PR DESCRIPTION
## Summary
- Remove local MCP server configuration from `.codex/config.toml`
- Delete the root `.mcp.json` file

## Notes
- This PR is separate from the Storybook UI gallery Pages PR.
- Generated `.pages/` output was left untracked and is not included.

## Validation
- Diff-only config cleanup; no runtime checks were required.