### PR TITLE
chore: group Renovate security updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,11 @@
 		schedule: ["before 5am on the first day of january,april,july,october"],
 	},
 	vulnerabilityAlerts: {
+		// GitHub/OSV vulnerability remediation can otherwise create one PR per advisory
+		// and bypass normal concurrency/schedule limits. Keep urgent security handling,
+		// but collect the currently rate-limited advisory fixes into a single PR.
+		groupName: "security updates",
+		branchTopic: "security-updates",
 		labels: ["security"],
 	},
 	packageRules: [


### PR DESCRIPTION
### Motivation
- Reduce noisy, rate-limited per-advisory Renovate PRs by grouping vulnerability remediation into a single predictable branch/PR so security fixes are easier to review and don't bypass normal concurrency/schedule limits.

### Description
- Add `groupName: "security updates"` and `branchTopic: "security-updates"` to `vulnerabilityAlerts` in `.github/renovate.json5`, preserving the existing `labels: ["security"]`, and commit the change.

### Testing
- Ran `git diff --check` which passed; attempted `pnpm exec renovate-config-validator .github/renovate.json5` which failed because the validator CLI is not available locally; ran `npx --yes --package renovate renovate-config-validator .github/renovate.json5` which reported `Invalid configuration option: toolSettings` (a pre-existing global-config validation issue unrelated to the added `vulnerabilityAlerts` fields).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a541c314c8329bedd1422ff26c9bf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * セキュリティ修正の更新が、個別の多数のPRではなく1つのPRにまとめられるようになりました。
  * これにより、セキュリティ関連の更新を確認・適用しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->