### PR TITLE
[codex] Make UI gallery a free-scroll canvas

### DIFF
--- a/scripts/build-ui-gallery.mjs
+++ b/scripts/build-ui-gallery.mjs
@@ -11,6 +11,9 @@ const storybookIndexPath = path.join(storybookDir, "index.json");
 
 const previewWidth = 430;
 const previewHeight = 520;
+const canvasColumns = 8;
+const canvasGap = 24;
+const canvasPadding = 32;
 
 function escapeHtml(value) {
 	return String(value)
@@ -28,17 +31,6 @@ function storyPath(entry) {
 	return "other";
 }
 
-function groupLabel(title) {
-	const parts = title.split("/");
-	if (parts[0] === "ui" || parts[0] === "forms" || parts[0] === "display") {
-		return "packages/ui";
-	}
-	if (parts[0] === "components") {
-		return parts.slice(0, 3).join("/");
-	}
-	return parts.slice(0, 2).join("/");
-}
-
 function normalizeStories(entries) {
 	return Object.values(entries)
 		.filter((entry) => entry.type === "story")
@@ -49,11 +41,10 @@ function normalizeStories(entries) {
 			importPath: entry.importPath ?? "",
 			componentPath: entry.componentPath ?? "",
 			source: storyPath(entry),
-			group: groupLabel(entry.title),
 		}))
 		.toSorted((a, b) => {
-			const byGroup = a.group.localeCompare(b.group);
-			if (byGroup !== 0) return byGroup;
+			const bySource = a.source.localeCompare(b.source);
+			if (bySource !== 0) return bySource;
 			const byTitle = a.title.localeCompare(b.title);
 			if (byTitle !== 0) return byTitle;
 			return a.name.localeCompare(b.name);
@@ -99,25 +90,25 @@ function renderRootIndex() {
 }
 
 function renderGallery(stories) {
-	const groups = Map.groupBy(stories, (story) => story.group);
-	const groupMarkup = [...groups.entries()]
-		.map(([group, groupStories]) => {
-			const cards = groupStories
-				.map((story) => {
-					const storyUrl = `./storybook/iframe.html?id=${encodeURIComponent(story.id)}&viewMode=story`;
-					const fullUrl = `./storybook/?path=/story/${encodeURIComponent(story.id)}`;
-					const searchable = [
-						story.group,
-						story.title,
-						story.name,
-						story.importPath,
-						story.componentPath,
-						story.source,
-					]
-						.join(" ")
-						.toLowerCase();
+	const canvasWidth =
+		canvasPadding * 2 +
+		canvasColumns * previewWidth +
+		(canvasColumns - 1) * canvasGap;
+	const cards = stories
+		.map((story) => {
+			const storyUrl = `./storybook/iframe.html?id=${encodeURIComponent(story.id)}&viewMode=story`;
+			const fullUrl = `./storybook/?path=/story/${encodeURIComponent(story.id)}`;
+			const searchable = [
+				story.source,
+				story.title,
+				story.name,
+				story.importPath,
+				story.componentPath,
+			]
+				.join(" ")
+				.toLowerCase();
 
-					return `<article class="story-card" data-story-card data-search="${escapeHtml(searchable)}">
+			return `<article class="story-card" data-story-card data-search="${escapeHtml(searchable)}">
 	<div class="story-frame">
 		<iframe title="${escapeHtml(`${story.title}: ${story.name}`)}" src="${storyUrl}" loading="lazy"></iframe>
 	</div>
@@ -129,19 +120,6 @@ function renderGallery(stories) {
 		<a href="${fullUrl}" target="_blank" rel="noreferrer">Open</a>
 	</div>
 </article>`;
-				})
-				.join("\n");
-
-			return `<section class="story-group" data-story-group>
-	<div class="group-heading">
-		<div>
-			<p>${escapeHtml(groupStories[0]?.source ?? "stories")}</p>
-			<h2>${escapeHtml(group)}</h2>
-		</div>
-		<span>${groupStories.length} stories</span>
-	</div>
-	<div class="story-row">${cards}</div>
-</section>`;
 		})
 		.join("\n");
 
@@ -164,8 +142,8 @@ function renderGallery(stories) {
 			font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 		}
 		* { box-sizing: border-box; }
-		html { scroll-behavior: smooth; }
-		body { margin: 0; background: var(--bg); color: var(--text); }
+		html { min-width: ${canvasWidth}px; }
+		body { margin: 0; min-width: ${canvasWidth}px; background: var(--bg); color: var(--text); }
 		header {
 			position: sticky;
 			top: 0;
@@ -201,29 +179,18 @@ function renderGallery(stories) {
 			color: var(--text);
 			font: inherit;
 		}
-		main { display: grid; gap: 32px; padding: 28px clamp(16px, 3vw, 32px) 56px; }
-		.story-group { display: grid; gap: 14px; }
-		.group-heading {
-			display: flex;
-			align-items: end;
-			justify-content: space-between;
-			gap: 12px;
+		main {
+			width: ${canvasWidth}px;
+			min-height: calc(100vh - 132px);
+			padding: ${canvasPadding}px;
 		}
-		.group-heading p { margin: 0 0 4px; color: var(--muted); font-size: 13px; }
-		.group-heading h2 { margin: 0; font-size: 20px; letter-spacing: 0; }
-		.group-heading span { color: var(--muted); font-size: 13px; white-space: nowrap; }
-		.story-row {
+		.canvas {
 			display: grid;
-			grid-auto-columns: ${previewWidth}px;
-			grid-auto-flow: column;
-			gap: 16px;
-			overflow-x: auto;
-			overscroll-behavior-x: contain;
-			scroll-snap-type: x proximity;
-			padding: 2px 4px 16px;
+			grid-template-columns: repeat(${canvasColumns}, ${previewWidth}px);
+			align-items: start;
+			gap: ${canvasGap}px;
 		}
 		.story-card {
-			scroll-snap-align: start;
 			display: grid;
 			grid-template-rows: ${previewHeight}px auto;
 			min-width: 0;
@@ -278,6 +245,7 @@ function renderGallery(stories) {
 		}
 		.empty {
 			display: none;
+			width: calc(${canvasWidth}px - ${canvasPadding * 2}px);
 			padding: 40px;
 			border: 1px dashed var(--border);
 			border-radius: 8px;
@@ -287,8 +255,6 @@ function renderGallery(stories) {
 		}
 		@media (max-width: 560px) {
 			.header-top { align-items: start; flex-direction: column; }
-			.story-row { grid-auto-columns: min(86vw, ${previewWidth}px); }
-			.story-card { grid-template-rows: min(${previewHeight}px, 108vw) auto; }
 		}
 		@media (prefers-color-scheme: dark) {
 			:root {
@@ -321,14 +287,13 @@ function renderGallery(stories) {
 	</header>
 	<main>
 		<div class="empty" id="empty">No stories match the current filter.</div>
-		${groupMarkup}
+		<div class="canvas">${cards}</div>
 	</main>
 	<script>
 		const searchInput = document.querySelector("#search");
 		const visibleCount = document.querySelector("#visible-count");
 		const empty = document.querySelector("#empty");
 		const cards = Array.from(document.querySelectorAll("[data-story-card]"));
-		const groups = Array.from(document.querySelectorAll("[data-story-group]"));
 
 		function applyFilter() {
 			const query = searchInput.value.trim().toLowerCase();
@@ -337,9 +302,6 @@ function renderGallery(stories) {
 				const visible = query === "" || card.dataset.search.includes(query);
 				card.hidden = !visible;
 				if (visible) shown += 1;
-			}
-			for (const group of groups) {
-				group.hidden = !group.querySelector("[data-story-card]:not([hidden])");
 			}
 			visibleCount.textContent = String(shown);
 			empty.style.display = shown === 0 ? "block" : "none";


### PR DESCRIPTION
## Summary

- Flatten the generated UI gallery into a single free-scroll canvas.
- Remove grouped lanes, headings, horizontal row containers, and scroll snapping.
- Keep Storybook iframe rendering, search, and story open links intact.

## Validation

- `node --check scripts/build-ui-gallery.mjs`
- `rg -n "story-group|story-row|scroll-snap|group-heading|overscroll|Map.groupBy|groupLabel" scripts/build-ui-gallery.mjs` returned no matches.

`pnpm exec oxfmt scripts/build-ui-gallery.mjs` could not complete locally because pnpm attempted dependency restoration and npm registry requests failed with `ENOTFOUND`; the stuck process was terminated.