### PR TITLE
Fix GitHub Pages docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      pages: write
     timeout-minutes: 10
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
@@ -26,6 +28,9 @@ jobs:
         run: pnpm pages:build
         env:
           SKIP_ENV_VALIDATION: "true"
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/scripts/build-ui-gallery.mjs
+++ b/scripts/build-ui-gallery.mjs
@@ -322,6 +322,7 @@ async function main() {
 	await mkdir(uiDir, { recursive: true });
 	await cp(storybookDir, storybookTargetDir, { recursive: true });
 	await cp(docsDir, path.join(pagesDir, "api"), { recursive: true });
+	await writeFile(path.join(pagesDir, ".nojekyll"), "");
 	await writeFile(path.join(pagesDir, "index.html"), renderRootIndex());
 	await writeFile(path.join(uiDir, "index.html"), renderGallery(stories));
 


### PR DESCRIPTION
### Motivation
- Pages deployment sometimes failed with "Deployment failed, try again later" because the Pages configuration step and required build permissions were missing. 
- TypeDoc/Storybook output contains files starting with `_`, so GitHub Pages needs a root `.nojekyll` to serve those files unchanged. 

### Description
- Add the official `actions/configure-pages@983d7736...` step before uploading the Pages artifact to ensure Pages metadata/config is created. 
- Grant the build job `contents: read` and `pages: write` permissions required by the configure step. 
- Emit a root `.nojekyll` file into the generated Pages artifact by writing `.nojekyll` in `scripts/build-ui-gallery.mjs`. 

### Testing
- Ran `pnpm pages:build` and the docs + Storybook build completed successfully. (passed)
- Ran `pnpm format:check .github/workflows/docs.yaml scripts/build-ui-gallery.mjs` and formatting checks passed. (passed)
- Ran `pnpm ui-gallery:build && test -f .pages/.nojekyll` and confirmed `.pages/.nojekyll` exists after the build. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a581967348329b7bc36a0a3f3827f)