### PR TITLE
chore(renovate): group pnpm overrides into one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,9 +72,10 @@
 		},
 		{
 			matchManagers: ["npm"],
-			matchDepTypes: ["pnpm.overrides"],
+			matchDepTypes: ["pnpm-workspace.overrides"],
 			groupName: "pnpm overrides",
 			groupSlug: "pnpm-overrides",
+			separateMajorMinor: false,
 			minimumReleaseAge: "2 days",
 			automerge: false,
 		},


### PR DESCRIPTION
## Summary

- match `pnpm-workspace.yaml` overrides with the correct Renovate dependency type
- keep major, minor, and patch override updates in one grouped PR

## Why

The existing rule used `pnpm.overrides`, which does not match overrides declared in `pnpm-workspace.yaml`. Renovate also separates major updates by default even when dependencies share a group.

## Impact

Future pnpm workspace override updates will be collected into the existing `pnpm overrides` group and proposed together, while automerge remains disabled.

## Checks

- `node_modules/.bin/oxfmt --check .github/renovate.json5`
- `git diff --check`
- Renovate config schema validation runs in the existing GitHub Actions workflow